### PR TITLE
Add 3D Skin Preview

### DIFF
--- a/SwiftCraftLauncher.xcodeproj/project.pbxproj
+++ b/SwiftCraftLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03A9887C2E75C96E005B7EFA /* SkinRenderKit in Frameworks */ = {isa = PBXBuildFile; productRef = 03A9887B2E75C96E005B7EFA /* SkinRenderKit */; };
 		9023D91C2E313A67005A53F1 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 9023D91B2E313A67005A53F1 /* ZIPFoundation */; };
 		9023D91F2E313A9C005A53F1 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 9023D91E2E313A9C005A53F1 /* MarkdownUI */; };
 		90C51D072E421BAB0014D7B4 /* MinecraftNBT in Frameworks */ = {isa = PBXBuildFile; productRef = 90C51D062E421BAB0014D7B4 /* MinecraftNBT */; };
@@ -31,6 +32,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				90C51D072E421BAB0014D7B4 /* MinecraftNBT in Frameworks */,
+				03A9887C2E75C96E005B7EFA /* SkinRenderKit in Frameworks */,
 				9023D91C2E313A67005A53F1 /* ZIPFoundation in Frameworks */,
 				9023D91F2E313A9C005A53F1 /* MarkdownUI in Frameworks */,
 				90E123456789ABCD0001 /* Sparkle in Frameworks */,
@@ -72,6 +74,7 @@
 				9023D91E2E313A9C005A53F1 /* MarkdownUI */,
 				90C51D062E421BAB0014D7B4 /* MinecraftNBT */,
 				90E123456789ABCD0002 /* Sparkle */,
+				03A9887B2E75C96E005B7EFA /* SkinRenderKit */,
 			);
 			productName = SwiftCraftLauncher;
 			productReference = BE59AB1B2E6B155200ECAB58 /* Swift Craft Launcher.app */;
@@ -109,6 +112,7 @@
 				90C51D052E421BAB0014D7B4 /* XCRemoteSwiftPackageReference "swift-nbt" */,
 				90E123456789ABCD0003 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				033870FA2E6059570056BDB2 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
+				03A9887A2E75C96E005B7EFA /* XCRemoteSwiftPackageReference "NSSkinRender" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9023D8282E3139B5005A53F1;
@@ -374,6 +378,14 @@
 				minimumVersion = 0.59.1;
 			};
 		};
+		03A9887A2E75C96E005B7EFA /* XCRemoteSwiftPackageReference "NSSkinRender" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/irisWirisW/NSSkinRender";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		9023D91A2E313A67005A53F1 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
@@ -413,6 +425,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 033870FA2E6059570056BDB2 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+		03A9887B2E75C96E005B7EFA /* SkinRenderKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03A9887A2E75C96E005B7EFA /* XCRemoteSwiftPackageReference "NSSkinRender" */;
+			productName = SkinRenderKit;
 		};
 		9023D91B2E313A67005A53F1 /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ab57a55851135cf042aa45da378d218d91289dca9cf8a63d60e832dcdc41e766",
+  "originHash" : "9280a0160be61afe798120c37442e1beb3db15f8b095cf2f650587ad2b42ac7c",
   "pins" : [
     {
       "identity" : "gzipswift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
         "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "nsskinrender",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/irisWirisW/NSSkinRender",
+      "state" : {
+        "branch" : "main",
+        "revision" : "502e40a60f5b2be9b0cfd95fc31d1db619c22d77"
       }
     },
     {


### PR DESCRIPTION
# Add 3D Skin Preview Support to Skin Manager

This pull request introduces **3D skin preview functionality** to enhance the skin management experience, allowing users to visualize their Minecraft skins in an interactive 3D environment.

## 🔧 Technical Changes

### Dependency Integration
* Added `NSSkinRender` Swift package dependency with `SkinRenderKit` product
* Updated project configuration files (`project.pbxproj`, `Package.resolved`)

### Feature Implementation  
* Integrated `SkinRenderKit` into `SkinToolDetailView.swift`
* Added state management for skin file paths and 3D preview visibility
* Implemented temporary file handling for skin preview compatibility

## ✨ User Experience Improvements

### Interactive 3D Preview
* Added "Preview 3D" toggle button to the skin selection interface
* Integrated `SkinRenderView` component for real-time 3D skin rendering
* Implemented fallback messaging for invalid skin files

### Enhanced Visual Feedback
Users can now:
- Toggle between 2D and 3D skin views seamlessly
- Interact with a fully rendered 3D Minecraft character model
- Preview skin appearance from multiple angles before selection

## 📸 Preview

The new 3D preview feature provides an immersive skin visualization experience:

<img width="447" height="358" alt="3D Skin Preview Interface showing interactive Minecraft character model with toggle controls" src="https://github.com/user-attachments/assets/7d980cd9-56d5-4c36-952e-7f6362ace2ef" />

*The interface now includes a 3D rendered Minecraft character model that users can interact with to preview their selected skins from all angles, significantly improving the skin selection experience.*

## 🎯 Impact

This enhancement significantly improves the skin management workflow by providing users with a comprehensive preview experience that matches modern Minecraft launcher standards, making skin selection more intuitive and visually engaging.