### PR TITLE
在macOS26下为CommonMenuPicker添加特定修饰符以控制宽度

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Views/CommonMenuPicker.swift
+++ b/SwiftCraftLauncher/CommonFeature/Views/CommonMenuPicker.swift
@@ -25,6 +25,7 @@ struct CommonMenuPicker<Label: View, SelectionValue: Hashable, Content: View>: V
         }
         .pickerStyle(.menu)
         .modifier(ConditionalLabelsHidden(isHidden: hidesLabel))
+        .modifier(FlexibleButtonSizingModifier())
     }
 }
 
@@ -35,6 +36,17 @@ private struct ConditionalLabelsHidden: ViewModifier {
     func body(content: Content) -> some View {
         if isHidden {
             content.labelsHidden()
+        } else {
+            content
+        }
+    }
+}
+
+private struct FlexibleButtonSizingModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content.buttonSizing(.flexible)
         } else {
             content
         }


### PR DESCRIPTION
https://developer.apple.com/forums/thread/801634
为26以及更高版本下的Picker添加.buttonSizing(.flexible)修饰符