### PR TITLE
fix: honor explicit non-default port in server connectivity check

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Utilities/NetworkUtils.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/NetworkUtils.swift
@@ -18,11 +18,11 @@ enum ServerConnectionStatus {
 }
 
 /// 解析后的服务器地址信息
-struct ResolvedServerAddress {
-    let address: String  // 实际连接的地址（SRV target 或原始地址）
-    let port: Int        // 实际连接的端口（SRV port 或原始端口）
-    let originalAddress: String  // 原始域名（用于 handshake）
-    let originalPort: Int        // 原始端口（用于 handshake）
+internal struct ResolvedServerAddress {
+    internal let address: String  // 实际连接的地址（SRV target 或原始地址）
+    internal let port: Int        // 实际连接的端口（SRV port 或原始端口）
+    internal let originalAddress: String  // 原始域名（用于 handshake）
+    internal let originalPort: Int        // 原始端口（用于 handshake）
 }
 
 /// 网络工具类
@@ -32,7 +32,16 @@ enum NetworkUtils {
     /// 根据用户输入自动判断端口，如果没有端口则查询 SRV 记录
     /// - Parameter input: 用户输入的地址（可能包含端口，如 "example.com:25565" 或 "example.com"）
     /// - Returns: 解析后的地址和端口（包含原始地址信息）
-    static func resolveServerAddress(_ input: String) async -> ResolvedServerAddress {
+    internal static func resolveServerAddress(_ input: String) async -> ResolvedServerAddress {
+        await resolveServerAddress(input, explicitPort: 25565)
+    }
+
+    /// 智能解析服务器地址，优先使用输入中的有效端口，其次使用显式非默认端口
+    /// - Parameters:
+    ///   - input: 用户输入的地址（可能包含端口）
+    ///   - explicitPort: 调用方传入的端口
+    /// - Returns: 解析后的地址和端口（包含原始地址信息）
+    internal static func resolveServerAddress(_ input: String, explicitPort: Int) async -> ResolvedServerAddress {
         let trimmed = input.trimmingCharacters(in: .whitespaces)
         var originalAddress = trimmed
         var originalPort = 25565
@@ -53,6 +62,16 @@ enum NetworkUtils {
                     originalPort: originalPort
                 )
             }
+        }
+
+        // 显式非默认端口由用户配置指定，不查询 SRV 记录
+        if explicitPort > 0 && explicitPort <= 65535 && explicitPort != 25565 {
+            return ResolvedServerAddress(
+                address: trimmed,
+                port: explicitPort,
+                originalAddress: trimmed,
+                originalPort: explicitPort
+            )
         }
 
         // 不包含端口，查询 SRV 记录
@@ -175,8 +194,8 @@ enum NetworkUtils {
         port: Int,
         timeout: TimeInterval = 5.0
     ) async -> ServerConnectionStatus {
-        // 解析服务器地址（查询 SRV 记录）
-        let resolved = await resolveServerAddress(address)
+        // 解析服务器地址（显式非默认端口不查询 SRV 记录）
+        let resolved = await resolveServerAddress(address, explicitPort: port)
 
         // 使用 Minecraft Server List Ping 协议获取服务器信息
         // 使用 SRV target + port 建立连接，但 handshake 使用原始域名

--- a/SwiftCraftLauncherTests/CommonFeature/Utilities/NetworkUtilsTests.swift
+++ b/SwiftCraftLauncherTests/CommonFeature/Utilities/NetworkUtilsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import SwiftCraftLauncher
+
+final class NetworkUtilsTests: XCTestCase {
+    func testResolveServerAddress_explicitNonDefaultPort() async {
+        let resolved = await NetworkUtils.resolveServerAddress("host", explicitPort: 30000)
+
+        XCTAssertEqual(resolved.address, "host")
+        XCTAssertEqual(resolved.port, 30000)
+        XCTAssertEqual(resolved.originalAddress, "host")
+        XCTAssertEqual(resolved.originalPort, 30000)
+    }
+
+    func testResolveServerAddress_zeroPortFallsBackToDefault() async {
+        let host = "this-host-should-not-resolve.invalid"
+        let resolved = await NetworkUtils.resolveServerAddress(host, explicitPort: 0)
+
+        XCTAssertEqual(resolved.address, host)
+        XCTAssertEqual(resolved.port, 25565)
+        XCTAssertEqual(resolved.originalAddress, host)
+        XCTAssertEqual(resolved.originalPort, 25565)
+    }
+
+    func testResolveServerAddress_embeddedPortWins() async {
+        let resolved = await NetworkUtils.resolveServerAddress("host:30000", explicitPort: 25565)
+
+        XCTAssertEqual(resolved.address, "host")
+        XCTAssertEqual(resolved.port, 30000)
+        XCTAssertEqual(resolved.originalAddress, "host")
+        XCTAssertEqual(resolved.originalPort, 30000)
+    }
+
+    func testResolveServerAddress_embeddedDefaultPort() async {
+        let resolved = await NetworkUtils.resolveServerAddress("host:25565", explicitPort: 25565)
+
+        XCTAssertEqual(resolved.address, "host")
+        XCTAssertEqual(resolved.port, 25565)
+        XCTAssertEqual(resolved.originalAddress, "host")
+        XCTAssertEqual(resolved.originalPort, 25565)
+    }
+
+    func testResolveServerAddress_invalidEmbeddedPortFallsBackToExplicitPort() async {
+        let resolved = await NetworkUtils.resolveServerAddress("host:notaport", explicitPort: 40000)
+
+        XCTAssertEqual(resolved.port, 40000)
+        XCTAssertEqual(resolved.originalPort, 40000)
+    }
+}


### PR DESCRIPTION
## Summary

Server connectivity checks ignored the configured port. `NetworkUtils.checkServerConnectionStatus(address:port:)` discarded its `port` argument and called `resolveServerAddress(address)` on the bare host. With no embedded `:port` in the host string, resolution fell through to an SRV lookup or the hard-coded `25565` default, so any server on a non-default port was always reported unreachable.

This passes the explicit port through to a new `resolveServerAddress(_:explicitPort:)` overload with this precedence:

1. A valid embedded port in the address (e.g. `host:30000`) still wins.
2. Otherwise, a valid non-default explicit port (`1...65535`, not `25565`) connects directly to `address:port` and skips SRV/default resolution.
3. The unset sentinel (`port == 0`, used when the port field is left empty) and any out-of-range value fall through to the existing SRV / `25565` default path, so servers saved without an explicit port behave exactly as before.

`resolveServerAddress` and `ResolvedServerAddress` are now `internal` so the precedence logic can be unit-tested.

## Why this matters

Adding a server on a port other than 25565 made the launcher's connectivity check fail even when the server was reachable, as reported in #249. The fix restores correct status for non-default ports without regressing the common default-port and SRV cases.

## Testing

Added `NetworkUtilsTests` covering the port-precedence rules:

- explicit non-default port resolves directly without SRV fallback
- embedded `:port` still takes precedence over the explicit argument
- embedded default port (`:25565`) is unchanged
- invalid embedded port falls back to the explicit port without crashing
- the `port == 0` sentinel falls back to the `25565` default (no direct port-0 ping)

The SRV branch is left untested as it shells out to `dig`. Full test suite passes locally (`xcodebuild test`).

Fixes #249

## Summary by Sourcery

Fix server connection status resolution to correctly apply explicit non-default ports while preserving existing SRV and default-port behavior.

Bug Fixes:
- Ensure server connectivity checks honor explicitly configured non-default ports instead of always falling back to SRV/default resolution.

Enhancements:
- Expose server address resolution helpers as internal to support unit testing of port precedence logic.

Tests:
- Add unit tests covering server address resolution precedence between embedded, explicit, default, and invalid ports.