### PR TITLE
feat: 调整三方登录刷新token

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Services/Yggdrasil/YggdrasilAuthService+TokenChain.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/Yggdrasil/YggdrasilAuthService+TokenChain.swift
@@ -80,10 +80,9 @@ extension YggdrasilAuthService {
             AppLog.common.info("Token refreshed successfully for server \(server.name)")
             return try JSONDecoder().decode(TokenResponse.self, from: data)
         } catch {
-            AppLog.common.error("Token refreshed failed for server \(server.name)")
             throw GlobalError.validation(
                 i18nKey: "error.validation.yggdrasil_token_response_parse_failed",
-                level: .notification,
+                level: .silent,
                 message: "Failed to parse Yggdrasil refresh token response from \(refreshTokenURL): \(error.localizedDescription)",
             )
         }
@@ -123,30 +122,37 @@ extension YggdrasilAuthService {
         )
     }
 
-    func getMinecraftToken(profile: YggdrasilProfile, server: YggdrasilServerConfig) async throws -> (minecraftToken: String, updatedProfile: YggdrasilProfile) {
-        let tokenResponse = try? await refreshToken(refreshToken: profile.refreshToken, server: server)
+    func getMinecraftToken(profile: YggdrasilProfile, server: YggdrasilServerConfig) async throws -> String {
+        var updatedProfile = profile
+        do {
+            let tokenResponse = try await refreshToken(
+                refreshToken: profile.refreshToken,
+                server: server,
+            )
+            updatedProfile = YggdrasilProfile(
+                id: profile.id,
+                name: profile.name,
+                skins: profile.skins,
+                capes: profile.capes,
+                accessToken: tokenResponse.accessToken,
+                refreshToken: tokenResponse.refreshToken ?? profile.refreshToken,
+                serverBaseURL: profile.serverBaseURL,
+            )
+        } catch {
+            DIContainer.shared.core.errorHandler.handle(error)
+        }
+
+        OfflineUserServerMap.setServer(updatedProfile)
 
         guard let parser = YggdrasilMinecraftTokenParsers.make(for: server.parserId) else {
             AppLog.common.error("TODO: Minecraft token fetch not yet implemented for this server (\(server.name)), falling back to OAuth2 token")
-            return (profile.accessToken, profile)
+            return updatedProfile.accessToken
         }
 
-        let minecraftToken = try await parser.fetchMinecraftToken(
-            profileId: profile.id,
+        return try await parser.fetchMinecraftToken(
+            profileId: updatedProfile.id,
             minecraftTokenURL: server.minecraftTokenURL,
-            oauthToken: profile.accessToken,
+            oauthToken: updatedProfile.accessToken,
         )
-
-        let updatedProfile = YggdrasilProfile(
-            id: profile.id,
-            name: profile.name,
-            skins: profile.skins,
-            capes: profile.capes,
-            accessToken: tokenResponse?.accessToken ?? profile.accessToken,
-            refreshToken: tokenResponse?.refreshToken ?? profile.refreshToken,
-            serverBaseURL: profile.serverBaseURL,
-        )
-
-        return (minecraftToken, updatedProfile)
     }
 }

--- a/SwiftCraftLauncher/CommonFeature/Utilities/OfflineUserServerMap.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/OfflineUserServerMap.swift
@@ -18,14 +18,14 @@ enum OfflineUserServerMap {
     }
 
     /// Associates a Yggdrasil profile with the specified user.
-    static func setServer(_ profile: YggdrasilProfile, for userId: String) {
+    static func setServer(_ profile: YggdrasilProfile) {
         var map = loadMap()
-        map[userId] = profile
+        map[profile.id] = profile
         if let data = try? JSONEncoder().encode(map) {
             UserDefaults.standard.set(data, forKey: AppConstants.UserDefaultsKeys.offlineUserServerMap)
-            AppLog.common.info("Updated Yggdrasil profile for user \(userId), server: \(profile.serverBaseURL)")
+            AppLog.common.info("Updated Yggdrasil profile for user \(profile.id), server: \(profile.serverBaseURL)")
         } else {
-            AppLog.common.error("Failed to encode Yggdrasil profile for user \(userId)")
+            AppLog.common.error("Failed to encode Yggdrasil profile for user \(profile.id)")
         }
     }
 

--- a/SwiftCraftLauncher/GameFeature/Run/MinecraftLaunchCommand.swift
+++ b/SwiftCraftLauncher/GameFeature/Run/MinecraftLaunchCommand.swift
@@ -134,11 +134,8 @@ struct MinecraftLaunchCommand {
         }
 
         let accessToken: String
-        let updatedProfile: YggdrasilProfile
         do {
-            let result = try await DIContainer.shared.system.yggdrasilAuthService.getMinecraftToken(profile: profile, server: server)
-            accessToken = result.minecraftToken
-            updatedProfile = result.updatedProfile
+            accessToken = try await DIContainer.shared.system.yggdrasilAuthService.getMinecraftToken(profile: profile, server: server)
         } catch {
             throw GlobalError.authentication(
                 i18nKey: "error.authentication.token_fetch_failed",
@@ -146,9 +143,6 @@ struct MinecraftLaunchCommand {
                 message: "Failed to fetch Minecraft token for profile=\(profile.serverBaseURL): \(error.localizedDescription)",
             )
         }
-
-        // Update the stored profile with refreshed tokens
-        OfflineUserServerMap.setServer(updatedProfile, for: player.id)
 
         let jarPath = AppConstants.AuthlibInjector.jarPath
         if !FileManager.default.fileExists(atPath: jarPath) {

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/ContentToolbarView.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/ContentToolbarView.swift
@@ -92,7 +92,7 @@ public struct ContentToolbarView: ToolbarContent {
                     },
                     onYggdrasilLogin: { profile in
                         AppLog.main.debug("Yggdrasil login successful, user: \(profile.name)")
-                        OfflineUserServerMap.setServer(profile, for: profile.id)
+                        OfflineUserServerMap.setServer(profile)
                         _ = playerListViewModel.addOnlinePlayer(profile: profile)
                         showingAddPlayerSheet = false
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/SwiftCraftLauncherTests/CommonFeature/Utilities/OfflineUserServerMapTests.swift
+++ b/SwiftCraftLauncherTests/CommonFeature/Utilities/OfflineUserServerMapTests.swift
@@ -50,7 +50,7 @@ final class OfflineUserServerMapTests: XCTestCase {
     func testSetServer_thenServerKey_returnsSameValue() {
         let userId = "round-trip-\(UUID().uuidString)"
         let profile = makeProfile(id: userId, serverBaseURL: "https://littleskin.cn/api")
-        OfflineUserServerMap.setServer(profile, for: userId)
+        OfflineUserServerMap.setServer(profile)
 
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userId), profile)
 
@@ -61,8 +61,8 @@ final class OfflineUserServerMapTests: XCTestCase {
         let userId = "overwrite-\(UUID().uuidString)"
         let profileA = makeProfile(id: userId, serverBaseURL: "https://server-a.com")
         let profileB = makeProfile(id: userId, serverBaseURL: "https://server-b.com")
-        OfflineUserServerMap.setServer(profileA, for: userId)
-        OfflineUserServerMap.setServer(profileB, for: userId)
+        OfflineUserServerMap.setServer(profileA)
+        OfflineUserServerMap.setServer(profileB)
 
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userId), profileB)
 
@@ -72,7 +72,7 @@ final class OfflineUserServerMapTests: XCTestCase {
     func testRemoveServer_existingMapping_returnsNil() {
         let userId = "remove-\(UUID().uuidString)"
         let profile = makeProfile(id: userId, serverBaseURL: "https://myserver.com")
-        OfflineUserServerMap.setServer(profile, for: userId)
+        OfflineUserServerMap.setServer(profile)
         OfflineUserServerMap.removeServer(for: userId)
 
         XCTAssertNil(OfflineUserServerMap.serverKey(for: userId))
@@ -90,8 +90,8 @@ final class OfflineUserServerMapTests: XCTestCase {
         let profileA = makeProfile(id: userA, serverBaseURL: "https://serverA.com")
         let profileB = makeProfile(id: userB, serverBaseURL: "https://serverB.com")
 
-        OfflineUserServerMap.setServer(profileA, for: userA)
-        OfflineUserServerMap.setServer(profileB, for: userB)
+        OfflineUserServerMap.setServer(profileA)
+        OfflineUserServerMap.setServer(profileB)
 
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userA), profileA)
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userB), profileB)
@@ -109,8 +109,8 @@ final class OfflineUserServerMapTests: XCTestCase {
         let profileA = makeProfile(id: userA, serverBaseURL: "https://s1.com")
         let profileB = makeProfile(id: userB, serverBaseURL: "https://s2.com")
 
-        OfflineUserServerMap.setServer(profileA, for: userA)
-        OfflineUserServerMap.setServer(profileB, for: userB)
+        OfflineUserServerMap.setServer(profileA)
+        OfflineUserServerMap.setServer(profileB)
 
         OfflineUserServerMap.removeServer(for: userA)
 
@@ -123,7 +123,7 @@ final class OfflineUserServerMapTests: XCTestCase {
     func testSetServer_specialCharacters() {
         let userId = "special-\(UUID().uuidString)"
         let profile = makeProfile(id: userId, serverBaseURL: "https://littleskin.cn/api")
-        OfflineUserServerMap.setServer(profile, for: userId)
+        OfflineUserServerMap.setServer(profile)
 
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userId)?.serverBaseURL, "https://littleskin.cn/api")
 
@@ -133,7 +133,7 @@ final class OfflineUserServerMapTests: XCTestCase {
     func testSetServer_emptyServerKey() {
         let userId = "empty-server-\(UUID().uuidString)"
         let profile = makeProfile(id: userId, serverBaseURL: "")
-        OfflineUserServerMap.setServer(profile, for: userId)
+        OfflineUserServerMap.setServer(profile)
 
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userId)?.serverBaseURL, "")
 
@@ -143,14 +143,14 @@ final class OfflineUserServerMapTests: XCTestCase {
     func testServerKey_longUserId() {
         let userId = String(repeating: "a", count: 1000)
         let profile = makeProfile(id: userId, serverBaseURL: "https://server.com")
-        OfflineUserServerMap.setServer(profile, for: userId)
+        OfflineUserServerMap.setServer(profile)
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: userId), profile)
         OfflineUserServerMap.removeServer(for: userId)
     }
 
     func testSetServer_emptyUserId() {
         let profile = makeProfile(id: "", serverBaseURL: "https://server.com")
-        OfflineUserServerMap.setServer(profile, for: "")
+        OfflineUserServerMap.setServer(profile)
         XCTAssertEqual(OfflineUserServerMap.serverKey(for: ""), profile)
         OfflineUserServerMap.removeServer(for: "")
     }

--- a/SwiftCraftLauncherTests/PlayerFeature/Models/PlayerAuthTests.swift
+++ b/SwiftCraftLauncherTests/PlayerFeature/Models/PlayerAuthTests.swift
@@ -144,8 +144,7 @@ final class PlayerAuthTests: XCTestCase {
 
         // Simulate offline third-party server mapping
         OfflineUserServerMap.setServer(
-            YggdrasilProfile(id: "uuid-4", name: "OfflineThirdParty", skins: [], capes: nil, accessToken: "token", refreshToken: "refresh", serverBaseURL: "https://yggdrasil-server.com"),
-            for: "uuid-4",
+            YggdrasilProfile(id: "uuid-4", name: "OfflineThirdParty", skins: [], capes: nil, accessToken: "token", refreshToken: "refresh", serverBaseURL: "https://yggdrasil-server.com")
         )
 
         // With server map entry, remote avatar player is NOT considered online

--- a/SwiftCraftLauncherTests/PlayerFeature/Models/PlayerAuthTests.swift
+++ b/SwiftCraftLauncherTests/PlayerFeature/Models/PlayerAuthTests.swift
@@ -144,7 +144,7 @@ final class PlayerAuthTests: XCTestCase {
 
         // Simulate offline third-party server mapping
         OfflineUserServerMap.setServer(
-            YggdrasilProfile(id: "uuid-4", name: "OfflineThirdParty", skins: [], capes: nil, accessToken: "token", refreshToken: "refresh", serverBaseURL: "https://yggdrasil-server.com")
+            YggdrasilProfile(id: "uuid-4", name: "OfflineThirdParty", skins: [], capes: nil, accessToken: "token", refreshToken: "refresh", serverBaseURL: "https://yggdrasil-server.com"),
         )
 
         // With server map entry, remote avatar player is NOT considered online


### PR DESCRIPTION
feat: 调整三方登录刷新token

## Summary by Sourcery

Adjust Yggdrasil login flow to refresh and persist tokens when fetching the Minecraft token.

New Features:
- Persist refreshed Yggdrasil profile data directly when obtaining a Minecraft token.

Bug Fixes:
- Ensure Minecraft token retrieval uses the latest access and refresh tokens after a successful refresh.

Enhancements:
- Change Yggdrasil token refresh parse failure notifications to be silent instead of user-facing.
- Simplify getMinecraftToken API to return only the token while handling profile persistence internally.
- Update OfflineUserServerMap to key profiles by their own IDs and streamline logging messages.
- Move offline Yggdrasil profile persistence from the launch command into the authentication service.