### PR TITLE
Feat favorites new

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Container/CoreContainer.swift
+++ b/SwiftCraftLauncher/CommonFeature/Container/CoreContainer.swift
@@ -44,6 +44,11 @@ final class CoreContainer {
     private let _gameActionManager = LazyContainer { GameActionManager() }
     var gameActionManager: GameActionManager { _gameActionManager.value() }
 
+    // Favorites
+
+    private let _favoriteStore = LazyContainer { FavoriteStore() }
+    var favoriteStore: FavoriteStore { _favoriteStore.value() }
+
     // Settings core
 
     private let _selectedGameManager = LazyContainer { SelectedGameManager() }

--- a/SwiftCraftLauncher/CommonFeature/Managers/AppCacheManager.swift
+++ b/SwiftCraftLauncher/CommonFeature/Managers/AppCacheManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Provides thread-safe JSON-based caching organized by namespaces.
 class AppCacheManager {
-    private let queue = DispatchQueue(label: "AppCacheManager.queue")
+    private let queue = DispatchQueue(label: "com.swiftcraftlauncher.appcachemanager")
 
     init() { }
 

--- a/SwiftCraftLauncher/CommonFeature/Utilities/AppConstants.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/AppConstants.swift
@@ -181,6 +181,7 @@ enum AppConstants {
         static let gameVersions = "game_versions"
         static let modCache = "mod_cache"
         static let skinLibrary = "skin_library"
+        static let favorites = "favorites"
     }
 
     /// Minecraft version constants.

--- a/SwiftCraftLauncher/GameFeature/Managers/ModCacheManager.swift
+++ b/SwiftCraftLauncher/GameFeature/Managers/ModCacheManager.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Provides a SQLite-backed cache for parsed mod metadata.
 class ModCacheManager {
     private let modCacheDB: ModCacheDatabase
-    private let queue = DispatchQueue(label: "ModCacheManager.queue")
+    private let queue = DispatchQueue(label: "com.swiftcraftlauncher.modcachemanager")
     private var isInitialized = false
 
     init() {

--- a/SwiftCraftLauncher/MainFeature/Views/DetailView.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/DetailView.swift
@@ -12,6 +12,7 @@ struct DetailView: View {
     @EnvironmentObject private var filterState: ResourceFilterState
     @EnvironmentObject private var detailState: ResourceDetailState
     @EnvironmentObject private var gameRepository: GameRepository
+    @EnvironmentObject private var container: DIContainer
 
     var body: some View {
         Group {
@@ -71,6 +72,7 @@ struct DetailView: View {
                 dataSource: filterState.dataSourceBinding,
                 searchText: filterState.searchTextBinding,
             )
+            .environmentObject(container.core.favoriteStore)
         }
     }
 }

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/GameToolbarItems.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/GameToolbarItems.swift
@@ -24,6 +24,8 @@ struct GameToolbarItems: View {
         if detailState.gameType {
             ResourceFilterMenus.dataSourceMenu(filterState: filterState)
                 .id(controlActiveState)
+            ResourceFilterMenus.favoritesFilterButton(filterState: filterState)
+                .id(controlActiveState)
         } else {
             ResourceFilterMenus.localResourceFilterMenu(filterState: filterState)
                 .id(controlActiveState)

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceFilterMenus.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceFilterMenus.swift
@@ -80,7 +80,7 @@ enum ResourceFilterMenus {
                 filterState.showFavoritesOnly
                     ? "resource.local_filter.all".localized()
                     : "favorites".localized(),
-                systemImage: filterState.showFavoritesOnly ? "heart.fill" : "heart"
+                systemImage: filterState.showFavoritesOnly ? "heart.fill" : "heart",
             )
             .labelStyle(.iconOnly)
             .applyReplaceTransition()

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceFilterMenus.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceFilterMenus.swift
@@ -71,6 +71,24 @@ enum ResourceFilterMenus {
         }
     }
 
+    /// A toggle button for filtering between all resources and favorites only.
+    static func favoritesFilterButton(filterState: ResourceFilterState) -> some View {
+        Button {
+            filterState.showFavoritesOnly.toggle()
+        } label: {
+            Label(
+                filterState.showFavoritesOnly
+                    ? "resource.local_filter.all".localized()
+                    : "favorites".localized(),
+                systemImage: filterState.showFavoritesOnly ? "heart.fill" : "heart"
+            )
+            .labelStyle(.iconOnly)
+            .applyReplaceTransition()
+            .foregroundStyle(filterState.showFavoritesOnly ? .red : .secondary)
+        }
+        .help(filterState.showFavoritesOnly ? "resource.local_filter.all".localized() : "favorites".localized())
+    }
+
     /// Provides a menu for filtering local resources by status, such as all or disabled.
     static func localResourceFilterMenu(filterState: ResourceFilterState) -> some View {
         Menu {

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceToolbarItems.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/ResourceToolbarItems.swift
@@ -179,6 +179,8 @@ struct ResourceToolbarItems: View {
                             detailState.gameResourcesType == ResourceType.minecraftJavaServer.rawValue,
                         )
                         .id(controlActiveState)
+                    ResourceFilterMenus.favoritesFilterButton(filterState: filterState)
+                        .id(controlActiveState)
                 }
             }
         }

--- a/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
@@ -10,7 +10,7 @@ import SQLite3
 
 /// Manages a local SQLite-backed collection of favorited Modrinth projects.
 final class FavoriteStore {
-    private let database: SQLiteDatabase
+    private let db: SQLiteDatabase
     private let tableName = AppConstants.DatabaseTables.favorites
     private var isInitialized = false
 
@@ -22,7 +22,7 @@ final class FavoriteStore {
     private let existsSQL: String
 
     init() {
-        database = SQLiteDatabase(path: AppPaths.gameVersionDatabase.path)
+        db = SQLiteDatabase.database(at: AppPaths.gameVersionDatabase.path)
         createTableSQL = """
         CREATE TABLE IF NOT EXISTS \(tableName) (
             id TEXT NOT NULL,
@@ -47,16 +47,15 @@ final class FavoriteStore {
     }
 
     /// Adds a favorite entry.
-    @discardableResult
-    func addFavorite(id: String, type: String, detail: ModrinthProjectDetail) -> Bool {
-        do {
-            try initializeIfNeeded()
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let jsonData = try encoder.encode(detail)
-            let now = Date()
+    func addFavorite(id: String, type: String, detail: ModrinthProjectDetail) throws {
+        try initializeIfNeeded()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let jsonData = try encoder.encode(detail)
+        let now = Date()
 
-            try executeUpdate(insertSQL) { statement in
+        try db.transaction {
+            try withPreparedStatement(insertSQL) { statement in
                 SQLiteDatabase.bind(statement, index: 1, value: id)
                 SQLiteDatabase.bind(statement, index: 2, value: type)
                 SQLiteDatabase.bind(statement, index: 3, data: jsonData)
@@ -64,142 +63,124 @@ final class FavoriteStore {
                 SQLiteDatabase.bind(statement, index: 5, value: type)
                 SQLiteDatabase.bind(statement, index: 6, value: now)
                 SQLiteDatabase.bind(statement, index: 7, value: now)
+                try stepStatement(statement)
             }
-            return true
-        } catch {
-            AppLog.common.error("Failed to add favorite id=\(id) type=\(type): \(error.localizedDescription)")
-            return false
         }
     }
 
     /// Removes a favorite entry.
-    @discardableResult
-    func removeFavorite(id: String, type: String) -> Bool {
-        do {
-            try initializeIfNeeded()
-            try executeUpdate(deleteSQL) { statement in
+    func removeFavorite(id: String, type: String) throws {
+        try initializeIfNeeded()
+        try db.transaction {
+            try withPreparedStatement(deleteSQL) { statement in
                 SQLiteDatabase.bind(statement, index: 1, value: id)
                 SQLiteDatabase.bind(statement, index: 2, value: type)
+                try stepStatement(statement)
             }
-            return true
-        } catch {
-            AppLog.common.error("Failed to remove favorite id=\(id) type=\(type): \(error.localizedDescription)")
-            return false
         }
     }
 
     /// Checks whether a project is favorited.
-    func isFavorite(id: String, type: String) -> Bool {
-        do {
-            try initializeIfNeeded()
-            return try withPreparedStatement(existsSQL) { statement in
-                SQLiteDatabase.bind(statement, index: 1, value: id)
-                SQLiteDatabase.bind(statement, index: 2, value: type)
-                return sqlite3_step(statement) == SQLITE_ROW
-            }
-        } catch {
-            AppLog.common.error("Failed to check favorite id=\(id) type=\(type): \(error.localizedDescription)")
-            return false
+    func isFavorite(id: String, type: String) throws -> Bool {
+        try initializeIfNeeded()
+        return try withPreparedStatement(existsSQL) { statement in
+            SQLiteDatabase.bind(statement, index: 1, value: id)
+            SQLiteDatabase.bind(statement, index: 2, value: type)
+            return sqlite3_step(statement) == SQLITE_ROW
         }
     }
 
     /// Retrieves all favorite entries for a given resource type.
-    func getFavorites(type: String) -> [ModrinthProjectDetail] {
-        do {
-            try initializeIfNeeded()
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+    func getFavorites(type: String) throws -> [ModrinthProjectDetail] {
+        try initializeIfNeeded()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
 
-            return try withPreparedStatement(selectByTypeSQL) { statement in
-                SQLiteDatabase.bind(statement, index: 1, value: type)
-                var results: [ModrinthProjectDetail] = []
-                while sqlite3_step(statement) == SQLITE_ROW {
-                    guard let jsonData = SQLiteDatabase.dataColumn(statement, index: 1) else { continue }
-                    if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
-                        results.append(detail)
-                    }
+        return try withPreparedStatement(selectByTypeSQL) { statement in
+            SQLiteDatabase.bind(statement, index: 1, value: type)
+            var results: [ModrinthProjectDetail] = []
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let jsonData = SQLiteDatabase.dataColumn(statement, index: 1) else { continue }
+                if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
+                    results.append(detail)
                 }
-                return results
             }
-        } catch {
-            AppLog.common.error("Failed to get favorites type=\(type): \(error.localizedDescription)")
-            return []
+            return results
         }
     }
 
     /// Retrieves all favorite entries across all resource types.
-    func getAllFavorites() -> [(id: String, type: String, detail: ModrinthProjectDetail)] {
-        do {
-            try initializeIfNeeded()
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+    func getAllFavorites() throws -> [(id: String, type: String, detail: ModrinthProjectDetail)] {
+        try initializeIfNeeded()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
 
-            return try withPreparedStatement(selectAllSQL) { statement in
-                var results: [(id: String, type: String, detail: ModrinthProjectDetail)] = []
-                while sqlite3_step(statement) == SQLITE_ROW {
-                    guard let id = SQLiteDatabase.stringColumn(statement, index: 0),
-                          let type = SQLiteDatabase.stringColumn(statement, index: 1),
-                          let jsonData = SQLiteDatabase.dataColumn(statement, index: 2) else { continue }
-                    if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
-                        results.append((id: id, type: type, detail: detail))
-                    }
+        return try withPreparedStatement(selectAllSQL) { statement in
+            var results: [(id: String, type: String, detail: ModrinthProjectDetail)] = []
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let id = SQLiteDatabase.stringColumn(statement, index: 0),
+                      let type = SQLiteDatabase.stringColumn(statement, index: 1),
+                      let jsonData = SQLiteDatabase.dataColumn(statement, index: 2) else { continue }
+                if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
+                    results.append((id: id, type: type, detail: detail))
                 }
-                return results
             }
-        } catch {
-            AppLog.common.error("Failed to get all favorites: \(error.localizedDescription)")
-            return []
+            return results
         }
     }
 
     /// Removes all favorite entries.
-    func clearAll() {
-        do {
-            try initializeIfNeeded()
-            try database.execute("DELETE FROM \(tableName)")
-        } catch {
-            AppLog.common.error("Failed to clear favorites: \(error.localizedDescription)")
+    func clearAll() throws {
+        try initializeIfNeeded()
+        try db.transaction {
+            try db.execute("DELETE FROM \(tableName)")
         }
     }
 
-    // MARK: - Private
-
     private func initializeIfNeeded() throws {
         guard !isInitialized else { return }
-        let dataDir = AppPaths.dataDirectory
-        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-        try database.open()
-        try database.execute(createTableSQL)
-        try? database.execute("CREATE INDEX IF NOT EXISTS idx_favorites_type ON \(tableName)(type);")
+        try ensureDirectoriesIfNeeded()
+        try db.open()
+        try createTableIfNeeded()
+        try createIndexesIfNeeded()
         isInitialized = true
+    }
+
+    private func ensureDirectoriesIfNeeded() throws {
+        try FileManager.default.createDirectory(
+            at: AppPaths.dataDirectory,
+            withIntermediateDirectories: true,
+        )
+    }
+
+    private func createTableIfNeeded() throws {
+        try db.execute(createTableSQL)
+    }
+
+    private func createIndexesIfNeeded() throws {
+        try? db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_favorites_type ON \(tableName)(type);",
+        )
     }
 
     private func withPreparedStatement<T>(
         _ sql: String,
         _ body: (OpaquePointer) throws -> T,
     ) throws -> T {
-        let statement = try database.prepare(sql)
+        let statement = try db.prepare(sql)
         defer { sqlite3_finalize(statement) }
         return try body(statement)
     }
 
-    private func executeUpdate(
-        _ sql: String,
-        bind: (OpaquePointer) throws -> Void,
-    ) throws {
-        try database.transaction {
-            try withPreparedStatement(sql) { statement in
-                try bind(statement)
-                guard sqlite3_step(statement) == SQLITE_DONE else {
-                    let db = database.database
-                    let msg = db.map { String(cString: sqlite3_errmsg($0)) } ?? "Unknown"
-                    throw GlobalError.validation(
-                        i18nKey: "error.validation.sql_execution_failed",
-                        level: .notification,
-                        message: "SQLite error: \(msg)",
-                    )
-                }
-            }
+    private func stepStatement(_ statement: OpaquePointer) throws {
+        let result = sqlite3_step(statement)
+        guard result == SQLITE_DONE else {
+            let errorMessage = String(cString: sqlite3_errmsg(db.database))
+            throw GlobalError.validation(
+                i18nKey: "error.validation.sql_execution_failed",
+                level: .notification,
+                message: "SQLite step failed, expected SQLITE_DONE. Error: \(errorMessage)",
+            )
         }
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
@@ -9,7 +9,12 @@ import Foundation
 import SQLite3
 
 /// Manages a local SQLite-backed collection of favorited Modrinth projects.
-final class FavoriteStore {
+///
+/// Maintains an in-memory map `[type: Set<id>]` that is kept in sync with the
+/// database. Database thread safety is handled by `SQLiteDatabase`'s internal
+/// serial queue. The in-memory map is updated on the main thread so SwiftUI
+/// observations remain responsive.
+final class FavoriteStore: ObservableObject {
     private let db: SQLiteDatabase
     private let tableName = AppConstants.DatabaseTables.favorites
     private var isInitialized = false
@@ -17,9 +22,10 @@ final class FavoriteStore {
     private let createTableSQL: String
     private let insertSQL: String
     private let deleteSQL: String
-    private let selectAllSQL: String
-    private let selectByTypeSQL: String
-    private let existsSQL: String
+    private let selectAllIdsByTypeSQL: String
+
+    /// All favorite project IDs grouped by type, kept in sync with the database.
+    @Published var favoriteIds: [String: Set<String>] = [:]
 
     init() {
         db = SQLiteDatabase.database(at: AppPaths.gameVersionDatabase.path)
@@ -27,7 +33,6 @@ final class FavoriteStore {
         CREATE TABLE IF NOT EXISTS \(tableName) (
             id TEXT NOT NULL,
             type TEXT NOT NULL,
-            project_detail BLOB NOT NULL,
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL,
             PRIMARY KEY (id, type)
@@ -35,42 +40,36 @@ final class FavoriteStore {
         """
         insertSQL = """
         INSERT OR REPLACE INTO \(tableName)
-        (id, type, project_detail, created_at, updated_at)
-        VALUES (?, ?, ?,
+        (id, type, created_at, updated_at)
+        VALUES (?, ?,
             COALESCE((SELECT created_at FROM \(tableName) WHERE id = ? AND type = ?), ?),
             ?)
         """
         deleteSQL = "DELETE FROM \(tableName) WHERE id = ? AND type = ?"
-        selectAllSQL = "SELECT id, type, project_detail FROM \(tableName) ORDER BY created_at DESC"
-        selectByTypeSQL = "SELECT id, project_detail FROM \(tableName) WHERE type = ? ORDER BY created_at DESC"
-        existsSQL = "SELECT 1 FROM \(tableName) WHERE id = ? AND type = ? LIMIT 1"
+        selectAllIdsByTypeSQL = "SELECT id, type FROM \(tableName)"
     }
 
-    /// Adds a favorite entry.
-    func addFavorite(id: String, type: String, detail: ModrinthProjectDetail) throws {
-        try initializeIfNeeded()
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
-        let jsonData = try encoder.encode(detail)
+    /// Adds a favorite entry and updates the in-memory map.
+    func addFavorite(id: String, type: String) throws {
+        try ensureInitialized()
         let now = Date()
-
         try db.transaction {
             try withPreparedStatement(insertSQL) { statement in
                 SQLiteDatabase.bind(statement, index: 1, value: id)
                 SQLiteDatabase.bind(statement, index: 2, value: type)
-                SQLiteDatabase.bind(statement, index: 3, data: jsonData)
-                SQLiteDatabase.bind(statement, index: 4, value: id)
-                SQLiteDatabase.bind(statement, index: 5, value: type)
+                SQLiteDatabase.bind(statement, index: 3, value: id)
+                SQLiteDatabase.bind(statement, index: 4, value: type)
+                SQLiteDatabase.bind(statement, index: 5, value: now)
                 SQLiteDatabase.bind(statement, index: 6, value: now)
-                SQLiteDatabase.bind(statement, index: 7, value: now)
                 try stepStatement(statement)
             }
         }
+        favoriteIds[type, default: []].insert(id)
     }
 
-    /// Removes a favorite entry.
+    /// Removes a favorite entry for a specific type and updates the in-memory map.
     func removeFavorite(id: String, type: String) throws {
-        try initializeIfNeeded()
+        try ensureInitialized()
         try db.transaction {
             try withPreparedStatement(deleteSQL) { statement in
                 SQLiteDatabase.bind(statement, index: 1, value: id)
@@ -78,89 +77,63 @@ final class FavoriteStore {
                 try stepStatement(statement)
             }
         }
+        favoriteIds[type]?.remove(id)
     }
 
-    /// Checks whether a project is favorited.
-    func isFavorite(id: String, type: String) throws -> Bool {
-        try initializeIfNeeded()
-        return try withPreparedStatement(existsSQL) { statement in
-            SQLiteDatabase.bind(statement, index: 1, value: id)
-            SQLiteDatabase.bind(statement, index: 2, value: type)
-            return sqlite3_step(statement) == SQLITE_ROW
-        }
+    /// Checks whether a project is favorited for a given type using the in-memory map.
+    func isFavorite(id: String, type: String) -> Bool {
+        try? ensureInitialized()
+        return favoriteIds[type]?.contains(id) ?? false
     }
 
-    /// Retrieves all favorite entries for a given resource type.
-    func getFavorites(type: String) throws -> [ModrinthProjectDetail] {
-        try initializeIfNeeded()
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-
-        return try withPreparedStatement(selectByTypeSQL) { statement in
-            SQLiteDatabase.bind(statement, index: 1, value: type)
-            var results: [ModrinthProjectDetail] = []
-            while sqlite3_step(statement) == SQLITE_ROW {
-                guard let jsonData = SQLiteDatabase.dataColumn(statement, index: 1) else { continue }
-                if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
-                    results.append(detail)
-                }
-            }
-            return results
-        }
-    }
-
-    /// Retrieves all favorite entries across all resource types.
-    func getAllFavorites() throws -> [(id: String, type: String, detail: ModrinthProjectDetail)] {
-        try initializeIfNeeded()
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-
-        return try withPreparedStatement(selectAllSQL) { statement in
-            var results: [(id: String, type: String, detail: ModrinthProjectDetail)] = []
-            while sqlite3_step(statement) == SQLITE_ROW {
-                guard let id = SQLiteDatabase.stringColumn(statement, index: 0),
-                      let type = SQLiteDatabase.stringColumn(statement, index: 1),
-                      let jsonData = SQLiteDatabase.dataColumn(statement, index: 2) else { continue }
-                if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
-                    results.append((id: id, type: type, detail: detail))
-                }
-            }
-            return results
-        }
-    }
-
-    /// Removes all favorite entries.
+    /// Removes all favorite entries and clears the in-memory map.
     func clearAll() throws {
-        try initializeIfNeeded()
+        try ensureInitialized()
         try db.transaction {
             try db.execute("DELETE FROM \(tableName)")
         }
+        favoriteIds.removeAll()
     }
 
-    private func initializeIfNeeded() throws {
+    // MARK: - Internal
+
+    private func loadAllIds() {
+        guard isInitialized else { return }
+        let pairs: [(id: String, type: String)]
+        do {
+            pairs = try withPreparedStatement(selectAllIdsByTypeSQL) { statement -> [(String, String)] in
+                var result: [(String, String)] = []
+                while sqlite3_step(statement) == SQLITE_ROW {
+                    if let id = SQLiteDatabase.stringColumn(statement, index: 0),
+                       let type = SQLiteDatabase.stringColumn(statement, index: 1) {
+                        result.append((id, type))
+                    }
+                }
+                return result
+            }
+        } catch {
+            return
+        }
+        var map: [String: Set<String>] = [:]
+        for (id, type) in pairs {
+            map[type, default: []].insert(id)
+        }
+        favoriteIds = map
+    }
+
+    private func ensureInitialized() throws {
         guard !isInitialized else { return }
-        try ensureDirectoriesIfNeeded()
-        try db.open()
-        try createTableIfNeeded()
-        try createIndexesIfNeeded()
-        isInitialized = true
-    }
-
-    private func ensureDirectoriesIfNeeded() throws {
         try FileManager.default.createDirectory(
             at: AppPaths.dataDirectory,
             withIntermediateDirectories: true,
         )
-    }
-
-    private func createTableIfNeeded() throws {
+        try db.open()
         try db.execute(createTableSQL)
-    }
-
-    private func createIndexesIfNeeded() throws {
         try? db.execute(
             "CREATE INDEX IF NOT EXISTS idx_favorites_type ON \(tableName)(type);",
         )
+        isInitialized = true
+        loadAllIds()
     }
 
     private func withPreparedStatement<T>(

--- a/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
@@ -95,8 +95,6 @@ final class FavoriteStore: ObservableObject {
         favoriteIds.removeAll()
     }
 
-    // MARK: - Internal
-
     private func loadAllIds() {
         guard isInitialized else { return }
         let pairs: [(id: String, type: String)]

--- a/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
@@ -64,7 +64,9 @@ final class FavoriteStore: ObservableObject {
                 try stepStatement(statement)
             }
         }
-        favoriteIds[type, default: []].insert(id)
+        DispatchQueue.main.async { [self] in
+            favoriteIds[type, default: []].insert(id)
+        }
     }
 
     /// Removes a favorite entry for a specific type and updates the in-memory map.
@@ -77,7 +79,9 @@ final class FavoriteStore: ObservableObject {
                 try stepStatement(statement)
             }
         }
-        favoriteIds[type]?.remove(id)
+        DispatchQueue.main.async { [self] in
+            favoriteIds[type]?.remove(id)
+        }
     }
 
     /// Checks whether a project is favorited for a given type using the in-memory map.
@@ -92,7 +96,9 @@ final class FavoriteStore: ObservableObject {
         try db.transaction {
             try db.execute("DELETE FROM \(tableName)")
         }
-        favoriteIds.removeAll()
+        DispatchQueue.main.async { [self] in
+            favoriteIds.removeAll()
+        }
     }
 
     private func loadAllIds() {

--- a/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Data/FavoriteStore.swift
@@ -1,0 +1,205 @@
+//
+//  FavoriteStore.swift
+//  ResourceFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+import SQLite3
+
+/// Manages a local SQLite-backed collection of favorited Modrinth projects.
+final class FavoriteStore {
+    private let database: SQLiteDatabase
+    private let tableName = AppConstants.DatabaseTables.favorites
+    private var isInitialized = false
+
+    private let createTableSQL: String
+    private let insertSQL: String
+    private let deleteSQL: String
+    private let selectAllSQL: String
+    private let selectByTypeSQL: String
+    private let existsSQL: String
+
+    init() {
+        database = SQLiteDatabase(path: AppPaths.gameVersionDatabase.path)
+        createTableSQL = """
+        CREATE TABLE IF NOT EXISTS \(tableName) (
+            id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            project_detail BLOB NOT NULL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (id, type)
+        );
+        """
+        insertSQL = """
+        INSERT OR REPLACE INTO \(tableName)
+        (id, type, project_detail, created_at, updated_at)
+        VALUES (?, ?, ?,
+            COALESCE((SELECT created_at FROM \(tableName) WHERE id = ? AND type = ?), ?),
+            ?)
+        """
+        deleteSQL = "DELETE FROM \(tableName) WHERE id = ? AND type = ?"
+        selectAllSQL = "SELECT id, type, project_detail FROM \(tableName) ORDER BY created_at DESC"
+        selectByTypeSQL = "SELECT id, project_detail FROM \(tableName) WHERE type = ? ORDER BY created_at DESC"
+        existsSQL = "SELECT 1 FROM \(tableName) WHERE id = ? AND type = ? LIMIT 1"
+    }
+
+    /// Adds a favorite entry.
+    @discardableResult
+    func addFavorite(id: String, type: String, detail: ModrinthProjectDetail) -> Bool {
+        do {
+            try initializeIfNeeded()
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let jsonData = try encoder.encode(detail)
+            let now = Date()
+
+            try executeUpdate(insertSQL) { statement in
+                SQLiteDatabase.bind(statement, index: 1, value: id)
+                SQLiteDatabase.bind(statement, index: 2, value: type)
+                SQLiteDatabase.bind(statement, index: 3, data: jsonData)
+                SQLiteDatabase.bind(statement, index: 4, value: id)
+                SQLiteDatabase.bind(statement, index: 5, value: type)
+                SQLiteDatabase.bind(statement, index: 6, value: now)
+                SQLiteDatabase.bind(statement, index: 7, value: now)
+            }
+            return true
+        } catch {
+            AppLog.common.error("Failed to add favorite id=\(id) type=\(type): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Removes a favorite entry.
+    @discardableResult
+    func removeFavorite(id: String, type: String) -> Bool {
+        do {
+            try initializeIfNeeded()
+            try executeUpdate(deleteSQL) { statement in
+                SQLiteDatabase.bind(statement, index: 1, value: id)
+                SQLiteDatabase.bind(statement, index: 2, value: type)
+            }
+            return true
+        } catch {
+            AppLog.common.error("Failed to remove favorite id=\(id) type=\(type): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Checks whether a project is favorited.
+    func isFavorite(id: String, type: String) -> Bool {
+        do {
+            try initializeIfNeeded()
+            return try withPreparedStatement(existsSQL) { statement in
+                SQLiteDatabase.bind(statement, index: 1, value: id)
+                SQLiteDatabase.bind(statement, index: 2, value: type)
+                return sqlite3_step(statement) == SQLITE_ROW
+            }
+        } catch {
+            AppLog.common.error("Failed to check favorite id=\(id) type=\(type): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Retrieves all favorite entries for a given resource type.
+    func getFavorites(type: String) -> [ModrinthProjectDetail] {
+        do {
+            try initializeIfNeeded()
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+
+            return try withPreparedStatement(selectByTypeSQL) { statement in
+                SQLiteDatabase.bind(statement, index: 1, value: type)
+                var results: [ModrinthProjectDetail] = []
+                while sqlite3_step(statement) == SQLITE_ROW {
+                    guard let jsonData = SQLiteDatabase.dataColumn(statement, index: 1) else { continue }
+                    if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
+                        results.append(detail)
+                    }
+                }
+                return results
+            }
+        } catch {
+            AppLog.common.error("Failed to get favorites type=\(type): \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Retrieves all favorite entries across all resource types.
+    func getAllFavorites() -> [(id: String, type: String, detail: ModrinthProjectDetail)] {
+        do {
+            try initializeIfNeeded()
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+
+            return try withPreparedStatement(selectAllSQL) { statement in
+                var results: [(id: String, type: String, detail: ModrinthProjectDetail)] = []
+                while sqlite3_step(statement) == SQLITE_ROW {
+                    guard let id = SQLiteDatabase.stringColumn(statement, index: 0),
+                          let type = SQLiteDatabase.stringColumn(statement, index: 1),
+                          let jsonData = SQLiteDatabase.dataColumn(statement, index: 2) else { continue }
+                    if let detail = try? decoder.decode(ModrinthProjectDetail.self, from: jsonData) {
+                        results.append((id: id, type: type, detail: detail))
+                    }
+                }
+                return results
+            }
+        } catch {
+            AppLog.common.error("Failed to get all favorites: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Removes all favorite entries.
+    func clearAll() {
+        do {
+            try initializeIfNeeded()
+            try database.execute("DELETE FROM \(tableName)")
+        } catch {
+            AppLog.common.error("Failed to clear favorites: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Private
+
+    private func initializeIfNeeded() throws {
+        guard !isInitialized else { return }
+        let dataDir = AppPaths.dataDirectory
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        try database.open()
+        try database.execute(createTableSQL)
+        try? database.execute("CREATE INDEX IF NOT EXISTS idx_favorites_type ON \(tableName)(type);")
+        isInitialized = true
+    }
+
+    private func withPreparedStatement<T>(
+        _ sql: String,
+        _ body: (OpaquePointer) throws -> T,
+    ) throws -> T {
+        let statement = try database.prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        return try body(statement)
+    }
+
+    private func executeUpdate(
+        _ sql: String,
+        bind: (OpaquePointer) throws -> Void,
+    ) throws {
+        try database.transaction {
+            try withPreparedStatement(sql) { statement in
+                try bind(statement)
+                guard sqlite3_step(statement) == SQLITE_DONE else {
+                    let db = database.database
+                    let msg = db.map { String(cString: sqlite3_errmsg($0)) } ?? "Unknown"
+                    throw GlobalError.validation(
+                        i18nKey: "error.validation.sql_execution_failed",
+                        level: .notification,
+                        message: "SQLite error: \(msg)",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/SwiftCraftLauncher/ResourceFeature/State/ResourceFilterState.swift
+++ b/SwiftCraftLauncher/ResourceFeature/State/ResourceFilterState.swift
@@ -27,6 +27,7 @@ final class ResourceFilterState: ObservableObject {
     @Published var dataSource: DataSource
     @Published var searchText: String = ""
     @Published var localResourceFilter: LocalResourceFilter = .all
+    @Published var showFavoritesOnly: Bool = false
 
     init(
         dataSource: DataSource? = nil,
@@ -109,5 +110,9 @@ final class ResourceFilterState: ObservableObject {
 
     var localResourceFilterBinding: Binding<LocalResourceFilter> {
         Binding(get: { [weak self] in self?.localResourceFilter ?? .all }, set: { [weak self] in self?.localResourceFilter = $0 })
+    }
+
+    var showFavoritesOnlyBinding: Binding<Bool> {
+        Binding(get: { [weak self] in self?.showFavoritesOnly ?? false }, set: { [weak self] in self?.showFavoritesOnly = $0 })
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Views/GameRemoteResourceView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/GameRemoteResourceView.swift
@@ -24,6 +24,7 @@ struct GameRemoteResourceView: View {
     @Binding var scannedDetailIds: Set<String> // detail IDs from the parent for fast lookup
     @Binding var dataSource: DataSource
     @Binding var searchText: String
+    @EnvironmentObject private var container: DIContainer
 
     init(
         game: GameVersionInfo,
@@ -77,5 +78,6 @@ struct GameRemoteResourceView: View {
             dataSource: $dataSource,
             searchText: $searchText,
         )
+        .environmentObject(container.core.favoriteStore)
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
@@ -38,7 +38,7 @@ struct FavoriteButton: View {
         .buttonStyle(.plain)
         .applyReplaceTransition()
         .task {
-            isFavorited = store.isFavorite(id: projectId, type: query)
+            isFavorited = (try? store.isFavorite(id: projectId, type: query)) ?? false
         }
     }
 
@@ -51,10 +51,10 @@ struct FavoriteButton: View {
         }
 
         if isFavorited {
-            store.removeFavorite(id: projectId, type: query)
+            try? store.removeFavorite(id: projectId, type: query)
         } else {
-            store.addFavorite(id: projectId, type: query, detail: detail)
+            try? store.addFavorite(id: projectId, type: query, detail: detail)
         }
-        isFavorited = store.isFavorite(id: projectId, type: query)
+        isFavorited = (try? store.isFavorite(id: projectId, type: query)) ?? false
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
@@ -1,0 +1,60 @@
+//
+//  FavoriteButton.swift
+//  ResourceFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import SwiftUI
+
+/// A button that toggles the favorite state of a Modrinth project.
+struct FavoriteButton: View {
+    let projectId: String
+    let query: String
+    @State private var isFavorited: Bool = false
+    @State private var isLoading: Bool = false
+
+    private let store = FavoriteStore()
+
+    var body: some View {
+        Button {
+            Task {
+                await toggleFavorite()
+            }
+        } label: {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .scaleEffect(1.3)
+                } else {
+                    Image(systemName: isFavorited ? "heart.fill" : "heart")
+                        .font(.system(size: 12))
+                        .foregroundColor(isFavorited ? .red : .secondary)
+                }
+            }
+            .frame(width: 16, height: 16)
+        }
+        .buttonStyle(.plain)
+        .applyReplaceTransition()
+        .task {
+            isFavorited = store.isFavorite(id: projectId, type: query)
+        }
+    }
+
+    private func toggleFavorite() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        guard let detail = try? await ModrinthService.fetchProjectDetailsThrowing(id: projectId) else {
+            return
+        }
+
+        if isFavorited {
+            store.removeFavorite(id: projectId, type: query)
+        } else {
+            store.addFavorite(id: projectId, type: query, detail: detail)
+        }
+        isFavorited = store.isFavorite(id: projectId, type: query)
+    }
+}

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 /// A button that toggles the favorite state of a Modrinth project.
 struct FavoriteButton: View {
-    @EnvironmentObject private var container: DIContainer
+    @EnvironmentObject private var favoriteStore: FavoriteStore
     let projectId: String
     let query: String
-    @State private var isFavorited: Bool = false
     @State private var isLoading: Bool = false
+
+    private var isFavorited: Bool {
+        favoriteStore.isFavorite(id: projectId, type: query)
+    }
 
     var body: some View {
         Button {
@@ -36,9 +39,6 @@ struct FavoriteButton: View {
         }
         .buttonStyle(.plain)
         .applyReplaceTransition()
-        .task {
-            isFavorited = container.core.favoriteStore.isFavorite(id: projectId, type: query)
-        }
     }
 
     private func toggleFavorite() async {
@@ -46,10 +46,9 @@ struct FavoriteButton: View {
         defer { isLoading = false }
 
         if isFavorited {
-            try? container.core.favoriteStore.removeFavorite(id: projectId, type: query)
+            try? favoriteStore.removeFavorite(id: projectId, type: query)
         } else {
-            try? container.core.favoriteStore.addFavorite(id: projectId, type: query)
+            try? favoriteStore.addFavorite(id: projectId, type: query)
         }
-        isFavorited = container.core.favoriteStore.isFavorite(id: projectId, type: query)
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/FavoriteButton.swift
@@ -9,12 +9,11 @@ import SwiftUI
 
 /// A button that toggles the favorite state of a Modrinth project.
 struct FavoriteButton: View {
+    @EnvironmentObject private var container: DIContainer
     let projectId: String
     let query: String
     @State private var isFavorited: Bool = false
     @State private var isLoading: Bool = false
-
-    private let store = FavoriteStore()
 
     var body: some View {
         Button {
@@ -38,7 +37,7 @@ struct FavoriteButton: View {
         .buttonStyle(.plain)
         .applyReplaceTransition()
         .task {
-            isFavorited = (try? store.isFavorite(id: projectId, type: query)) ?? false
+            isFavorited = container.core.favoriteStore.isFavorite(id: projectId, type: query)
         }
     }
 
@@ -46,15 +45,11 @@ struct FavoriteButton: View {
         isLoading = true
         defer { isLoading = false }
 
-        guard let detail = try? await ModrinthService.fetchProjectDetailsThrowing(id: projectId) else {
-            return
-        }
-
         if isFavorited {
-            try? store.removeFavorite(id: projectId, type: query)
+            try? container.core.favoriteStore.removeFavorite(id: projectId, type: query)
         } else {
-            try? store.addFavorite(id: projectId, type: query, detail: detail)
+            try? container.core.favoriteStore.addFavorite(id: projectId, type: query)
         }
-        isFavorited = (try? store.isFavorite(id: projectId, type: query)) ?? false
+        isFavorited = container.core.favoriteStore.isFavorite(id: projectId, type: query)
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
@@ -190,7 +190,7 @@ struct ModrinthDetailCardView: View {
             downloadInfoView
             followerInfoView
             HStack(spacing: 6) {
-                if !project.projectId.hasPrefix("local_"), !project.projectId.hasPrefix("file_") {
+                if type {
                     FavoriteButton(
                         projectId: project.projectId,
                         query: query,

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
@@ -66,6 +66,7 @@ struct ModrinthDetailCardView: View {
     @State private var showDeleteAlert = false
     @State private var isResourceDisabled: Bool = false
     @EnvironmentObject private var gameRepository: GameRepository
+    @EnvironmentObject private var container: DIContainer
 
     enum AddButtonState {
         case idle
@@ -195,6 +196,7 @@ struct ModrinthDetailCardView: View {
                         projectId: project.projectId,
                         query: query,
                     )
+                    .environmentObject(container.core.favoriteStore)
                 }
                 AddOrDeleteResourceButton(
                     project: project,

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailCardView.swift
@@ -204,22 +204,30 @@ struct ModrinthDetailCardView: View {
         VStack(alignment: .trailing, spacing: ModrinthConstants.UIConstants.spacing) {
             downloadInfoView
             followerInfoView
-            AddOrDeleteResourceButton(
-                project: project,
-                selectedVersions: selectedVersions,
-                selectedLoaders: selectedLoaders,
-                gameInfo: gameInfo,
-                query: query,
-                type: type,
-                selectedItem: $selectedItem,
-                onResourceChanged: onResourceChanged,
-                scannedDetailIds: $scannedDetailIds,
-                isResourceDisabled: $isResourceDisabled,
-                onResourceUpdated: onResourceUpdated,
-            ) { isDisabled in
-                onLocalDisableStateChanged?(project, isDisabled)
+            HStack(spacing: 6) {
+                if !project.projectId.hasPrefix("local_"), !project.projectId.hasPrefix("file_") {
+                    FavoriteButton(
+                        projectId: project.projectId,
+                        query: query,
+                    )
+                }
+                AddOrDeleteResourceButton(
+                    project: project,
+                    selectedVersions: selectedVersions,
+                    selectedLoaders: selectedLoaders,
+                    gameInfo: gameInfo,
+                    query: query,
+                    type: type,
+                    selectedItem: $selectedItem,
+                    onResourceChanged: onResourceChanged,
+                    scannedDetailIds: $scannedDetailIds,
+                    isResourceDisabled: $isResourceDisabled,
+                    onResourceUpdated: onResourceUpdated,
+                ) { isDisabled in
+                    onLocalDisableStateChanged?(project, isDisabled)
+                }
+                .environmentObject(gameRepository)
             }
-            .environmentObject(gameRepository)
         }
     }
 

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
@@ -186,7 +186,7 @@ struct ModrinthDetailView: View {
                 ModrinthDetailListSkeletonRows()
             } else {
                 let filteredResults = filterState.showFavoritesOnly
-                    ? viewModel.results.filter { favoriteStore.isFavorite(id: $0.projectId, type: query) }
+                    ? viewModel.results.filter { (try? favoriteStore.isFavorite(id: $0.projectId, type: query)) ?? false }
                     : viewModel.results
                 ForEach(filteredResults, id: \.projectId) { mod in
                     ModrinthDetailCardView(

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
@@ -28,7 +28,7 @@ struct ModrinthDetailView: View {
     @Binding var searchText: String
     @StateObject private var coordinator = ModrinthDetailCoordinatorViewModel()
     @EnvironmentObject private var filterState: ResourceFilterState
-    private let favoriteStore = FavoriteStore()
+    @EnvironmentObject private var favoriteStore: FavoriteStore
 
     init(
         query: String,
@@ -186,7 +186,7 @@ struct ModrinthDetailView: View {
                 ModrinthDetailListSkeletonRows()
             } else {
                 let filteredResults = filterState.showFavoritesOnly
-                    ? viewModel.results.filter { (try? favoriteStore.isFavorite(id: $0.projectId, type: query)) ?? false }
+                    ? viewModel.results.filter { favoriteStore.isFavorite(id: $0.projectId, type: query) }
                     : viewModel.results
                 ForEach(filteredResults, id: \.projectId) { mod in
                     ModrinthDetailCardView(

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthDetailView.swift
@@ -27,6 +27,8 @@ struct ModrinthDetailView: View {
     @StateObject private var viewModel = ModrinthSearchViewModel()
     @Binding var searchText: String
     @StateObject private var coordinator = ModrinthDetailCoordinatorViewModel()
+    @EnvironmentObject private var filterState: ResourceFilterState
+    private let favoriteStore = FavoriteStore()
 
     init(
         query: String,
@@ -183,7 +185,10 @@ struct ModrinthDetailView: View {
             if viewModel.isLoading {
                 ModrinthDetailListSkeletonRows()
             } else {
-                ForEach(viewModel.results, id: \.projectId) { mod in
+                let filteredResults = filterState.showFavoritesOnly
+                    ? viewModel.results.filter { favoriteStore.isFavorite(id: $0.projectId, type: query) }
+                    : viewModel.results
+                ForEach(filteredResults, id: \.projectId) { mod in
                     ModrinthDetailCardView(
                         project: mod,
                         selectedVersions: selectedVersions,

--- a/SwiftCraftLauncher/Resources/Localizable.xcstrings
+++ b/SwiftCraftLauncher/Resources/Localizable.xcstrings
@@ -9914,143 +9914,6 @@
         }
       }
     },
-    "error.authentication.token_fetch_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل في الحصول على رمز الوصول"
-          }
-        },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke hente adgangstoken"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriffstoken konnte nicht abgerufen werden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to fetch access token"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo obtener el token de acceso"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pääsytunnuksen haku epäonnistui"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de l'obtention du jeton d'accès"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "एक्सेस टोकन प्राप्त करने में विफल"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile ottenere il token di accesso"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクセストークンの取得に失敗しました"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "액세스 토큰을 가져오지 못했습니다"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke hente tilgangstoken"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan toegangstoken niet ophalen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się pobrać tokena dostępu"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao obter o token de acesso"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось получить токен доступа"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunde inte hämta åtkomsttoken"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ไม่สามารถดึงโทเค็นการเข้าถึงได้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erişim token'ı alınamadı"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể lấy token truy cập"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "获取访问令牌失败"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法取得存取權杖"
-          }
-        }
-      }
-    },
     "error.authentication.invalid_refresh_token" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -11418,6 +11281,143 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入已過期，請重新登入該帳戶"
+          }
+        }
+      }
+    },
+    "error.authentication.token_fetch_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فشل في الحصول على رمز الوصول"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke hente adgangstoken"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zugriffstoken konnte nicht abgerufen werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to fetch access token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo obtener el token de acceso"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pääsytunnuksen haku epäonnistui"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'obtention du jeton d'accès"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक्सेस टोकन प्राप्त करने में विफल"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile ottenere il token di accesso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセストークンの取得に失敗しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "액세스 토큰을 가져오지 못했습니다"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke hente tilgangstoken"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kan toegangstoken niet ophalen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się pobrać tokena dostępu"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falha ao obter o token de acesso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить токен доступа"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunde inte hämta åtkomsttoken"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ไม่สามารถดึงโทเค็นการเข้าถึงได้"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erişim token'ı alınamadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể lấy token truy cập"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取访问令牌失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法取得存取權杖"
           }
         }
       }
@@ -39527,6 +39527,143 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fabric 加載器"
+          }
+        }
+      }
+    },
+    "favorites" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المفضلة"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritter"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suosikit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पसंदीदा"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferiti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾기"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritter"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorieten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ulubione"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Избранное"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriter"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รายการโปรด"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriler"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yêu thích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
           }
         }
       }


### PR DESCRIPTION
## Summary by Sourcery

Add persistent favorites support for Modrinth resources, including UI controls to mark projects as favorites and filter remote resource lists by favorite status.

New Features:
- Introduce a SQLite-backed FavoriteStore to persist and manage favorited Modrinth projects.
- Add a FavoriteButton to toggle favorite status for individual Modrinth projects.
- Add a favorites-only filter in resource toolbars and detail views to show only favorited remote resources.

Enhancements:
- Wire the FavoriteStore into the dependency container and propagate it through relevant views via environment objects.
- Update resource detail cards to show a favorite toggle alongside the add/delete resource controls.
- Extend ResourceFilterState with a favorites-only flag and binding to support UI filtering.
- Adjust cache manager dispatch queue labels to use stable, namespaced identifiers.