### PR TITLE
feat: 新增启动游戏的时候进行内存压力检测

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Container/UIContainer.swift
+++ b/SwiftCraftLauncher/CommonFeature/Container/UIContainer.swift
@@ -29,6 +29,11 @@ final class UIContainer {
         _authlibInjectorMissingPresenter.value()
     }
 
+    private let _memoryPressureAlertPresenter = MainActorLazyContainer { MemoryPressureAlertPresenter() }
+    @MainActor var memoryPressureAlertPresenter: MemoryPressureAlertPresenter {
+        _memoryPressureAlertPresenter.value()
+    }
+
     private let _openURLModPackImportPresenter = MainActorLazyContainer { OpenURLModPackImportPresenter() }
     @MainActor var openURLModPackImportPresenter: OpenURLModPackImportPresenter {
         _openURLModPackImportPresenter.value()

--- a/SwiftCraftLauncher/CommonFeature/Utilities/AppConstants.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/AppConstants.swift
@@ -40,6 +40,7 @@ enum AppConstants {
         static let globalXms = "globalXms"
         static let globalXmx = "globalXmx"
         static let enableAICrashAnalysis = "enableAICrashAnalysis"
+        static let enableMemoryPressureWarning = "enableMemoryPressureWarning"
         static let defaultAPISource = "defaultAPISource"
         static let includeSnapshotsForGameVersions = "includeSnapshotsForGameVersions"
         static let syncLanguageForNewGames = "syncLanguageForNewGames"

--- a/SwiftCraftLauncher/GameFeature/Managers/GameSettingsManager.swift
+++ b/SwiftCraftLauncher/GameFeature/Managers/GameSettingsManager.swift
@@ -46,6 +46,11 @@ class GameSettingsManager: ObservableObject {
         didSet { objectWillChange.send() }
     }
 
+    @AppStorage(AppConstants.UserDefaultsKeys.enableMemoryPressureWarning)
+    var enableMemoryPressureWarning: Bool = true {
+        didSet { objectWillChange.send() }
+    }
+
     @AppStorage(AppConstants.UserDefaultsKeys.defaultAPISource)
     var defaultAPISource: DataSource = .modrinth {
         didSet { objectWillChange.send() }

--- a/SwiftCraftLauncher/GameFeature/Run/MemoryPressureAlertPresenter.swift
+++ b/SwiftCraftLauncher/GameFeature/Run/MemoryPressureAlertPresenter.swift
@@ -1,0 +1,50 @@
+//
+//  MemoryPressureAlertPresenter.swift
+//  GameFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+
+/// A choice the user makes when a memory pressure warning is shown.
+enum MemoryPressureChoice {
+    /// Proceed with the launch despite elevated memory pressure.
+    case continueAnyway
+    /// Cancel the launch.
+    case cancel
+}
+
+/// Presents a confirmation prompt when the system is under memory pressure before launch.
+///
+/// The main window observes ``isPresented`` and displays a modal. The launch
+/// flow suspends until the user makes a choice or the prompt is dismissed.
+@MainActor
+final class MemoryPressureAlertPresenter: ObservableObject {
+    @Published private(set) var isPresented = false
+    @Published private(set) var pressureLevel: MemoryPressureLevel = .normal
+
+    private var continuation: CheckedContinuation<MemoryPressureChoice, Never>?
+
+    init() { }
+
+    func requestUserChoice(for level: MemoryPressureLevel) async -> MemoryPressureChoice {
+        if let continuation {
+            continuation.resume(returning: .cancel)
+            self.continuation = nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            self.pressureLevel = level
+            isPresented = true
+        }
+    }
+
+    func resolve(_ choice: MemoryPressureChoice) {
+        guard let continuation else { return }
+        self.continuation = nil
+        isPresented = false
+        continuation.resume(returning: choice)
+    }
+}

--- a/SwiftCraftLauncher/GameFeature/Run/MemoryPressureChecker.swift
+++ b/SwiftCraftLauncher/GameFeature/Run/MemoryPressureChecker.swift
@@ -1,0 +1,45 @@
+//
+//  MemoryPressureChecker.swift
+//  GameFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+
+/// Represents the macOS memory pressure level reported by the kernel.
+enum MemoryPressureLevel {
+    case normal
+    case warning
+    case critical
+
+    /// Whether the system is under elevated memory pressure.
+    var isElevated: Bool { self != .normal }
+
+    var localizedMessage: String {
+        switch self {
+        case .normal: ""
+        case .warning: "game_launch.memory_pressure.warning_message".localized()
+        case .critical: "game_launch.memory_pressure.critical_message".localized()
+        }
+    }
+}
+
+/// Queries the macOS kernel for the current memory pressure level.
+enum MemoryPressureChecker {
+    /// Returns the current memory pressure level via `kern.memorystatus_vm_pressure_level`.
+    static func check() -> MemoryPressureLevel {
+        var value: UInt32 = 0
+        var size = MemoryLayout<UInt32>.size
+        let result = sysctlbyname("kern.memorystatus_vm_pressure_level", &value, &size, nil, 0)
+        guard result == 0 else {
+            AppLog.game.warning("Failed to query memory pressure level, sysctl returned \(result)")
+            return .normal
+        }
+        switch value {
+        case 2: return .warning
+        case 4: return .critical
+        default: return .normal
+        }
+    }
+}

--- a/SwiftCraftLauncher/GameFeature/Run/MinecraftLaunchCommand.swift
+++ b/SwiftCraftLauncher/GameFeature/Run/MinecraftLaunchCommand.swift
@@ -28,6 +28,10 @@ struct MinecraftLaunchCommand {
     func launchGameThrowing() async throws {
         let validatedPlayer = try await validatePlayerTokenBeforeLaunch()
 
+        if DIContainer.shared.ui.gameSettingsManager.enableMemoryPressureWarning {
+            guard await checkMemoryPressure() else { return }
+        }
+
         let command = game.launchCommand
         try await launchGameProcess(
             command: try await replaceAuthParameters(command: command, with: validatedPlayer),
@@ -77,6 +81,16 @@ struct MinecraftLaunchCommand {
                 userInfo: ["updatedPlayer": updatedPlayer],
             )
         }
+    }
+
+    private func checkMemoryPressure() async -> Bool {
+        let level = MemoryPressureChecker.check()
+        guard level.isElevated else { return true }
+
+        AppLog.game.warning("Memory pressure is \(String(describing: level)) before launching \(game.gameName)")
+
+        let choice = await DIContainer.shared.ui.memoryPressureAlertPresenter.requestUserChoice(for: level)
+        return choice == .continueAnyway
     }
 
     private func replaceAuthParameters(command: [String], with validatedPlayer: Player) async throws -> [String] {

--- a/SwiftCraftLauncher/GameFeature/Views/Settings/GameSettingsView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/Settings/GameSettingsView.swift
@@ -74,6 +74,18 @@ public struct GameSettingsView: View {
                 .labeledContentStyle(.custom)
                 .padding(.bottom, 10)
 
+                LabeledContent("settings.memory_pressure_warning.label".localized()) {
+                    HStack {
+                        Toggle(
+                            "",
+                            isOn: $gameSettingsManager.enableMemoryPressureWarning,
+                        ).labelsHidden()
+                        Text("settings.memory_pressure_warning.description".localized())
+                    }
+                }
+                .labeledContentStyle(.custom)
+                .padding(.bottom, 10)
+
                 LabeledContent("settings.game.language.label".localized()) {
                     HStack {
                         Toggle(

--- a/SwiftCraftLauncher/MainFeature/Utilities/MainViewPresentationModifier.swift
+++ b/SwiftCraftLauncher/MainFeature/Utilities/MainViewPresentationModifier.swift
@@ -52,6 +52,7 @@ struct MainViewPresentationModifier: ViewModifier {
                 detailState: detailState,
             )
             .authlibInjectorMissingAlert(container)
+            .memoryPressureAlert(container)
     }
 }
 

--- a/SwiftCraftLauncher/MainFeature/Utilities/MemoryPressureAlertModifier.swift
+++ b/SwiftCraftLauncher/MainFeature/Utilities/MemoryPressureAlertModifier.swift
@@ -1,0 +1,57 @@
+//
+//  MemoryPressureAlertModifier.swift
+//  MainFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import SwiftUI
+
+/// Presents an alert when the system is under memory pressure before game launch.
+struct MemoryPressureAlertModifier: ViewModifier {
+    @StateObject private var memoryPressureAlertPresenter: MemoryPressureAlertPresenter
+
+    init(
+        memoryPressureAlertPresenter: MemoryPressureAlertPresenter,
+    ) {
+        _memoryPressureAlertPresenter = StateObject(wrappedValue: memoryPressureAlertPresenter)
+    }
+
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { memoryPressureAlertPresenter.isPresented },
+            set: { newValue in
+                if !newValue {
+                    memoryPressureAlertPresenter.resolve(.cancel)
+                }
+            },
+        )
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .alert(
+                "game_launch.memory_pressure.title".localized(),
+                isPresented: alertBinding,
+            ) {
+                Button("common.continue".localized()) {
+                    memoryPressureAlertPresenter.resolve(.continueAnyway)
+                }
+                Button("common.close".localized(), role: .cancel) {
+                    memoryPressureAlertPresenter.resolve(.cancel)
+                }
+            } message: {
+                Text(memoryPressureAlertPresenter.pressureLevel.localizedMessage)
+            }
+    }
+}
+
+extension View {
+    func memoryPressureAlert(
+        _ container: DIContainer,
+    ) -> some View {
+        modifier(MemoryPressureAlertModifier(
+            memoryPressureAlertPresenter: container.ui.memoryPressureAlertPresenter,
+        ))
+    }
+}

--- a/SwiftCraftLauncher/Resources/Localizable.xcstrings
+++ b/SwiftCraftLauncher/Resources/Localizable.xcstrings
@@ -41865,6 +41865,417 @@
         }
       }
     },
+    "game_launch.memory_pressure.critical_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نظامك يعاني من ضغطذاكرة حرج. يُنصح بشدة بعدم تشغيل اللعبة."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit system har kritisk hukommelsespresion. Det frarådes kraftigt at starte spillet."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihr System unterliegt einem kritischen Speicherdruck. Das Starten des Spiels wird dringend nicht empfohlen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your system is under critical memory pressure. Launching the game is strongly discouraged."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Su sistema está bajo presión de memoria crítica. Se desaconseja encarecidamente iniciar el juego."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmässäsi on kriittinen muistipaine. Pelin käynnistäminen on erittäin epäsuositeltua."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre système est sous pression mémoire critique. Le lancement du jeu est fortement déconseillé."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपके सिस्टम में गंभीर मेमोरी दबाव है। गेम लॉन्च करने की दृढ़ता से अनुशंसा नहीं की जाती।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il sistema è sotto pressione sulla memoria critica. L'avvio del gioco è fortemente sconsigliato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムに重大なメモリプレッシャーがあります。ゲームの起動は強く推奨されません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템에 심각한 메모리 압력이 있습니다. 게임 시작은 강력히 권장되지 않습니다."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemet ditt har kritisk minnetrykk. Det frarådes på det sterkeste å starte spillet."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uw systeem heeft kritieke geheugendruk. Het starten van het spel wordt ten zeerste afgeraden."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twój system jest pod krytycznym ciśnieniem pamięci. Uruchomienie gry jest zdecydowanie odradzane."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu sistema está sob pressão de memória crítica. Iniciar o jogo é fortemente desencorajado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша система испытывает критическое давление памяти. Запуск игры настоятельно не рекомендуется."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditt system har kritiskt minnestryck. Att starta spelet rekommenderas starkt inte."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ระบบของคุณมีแรงกดดันหน่วยความจำวิกฤต การเริ่มเกมไม่แนะนำอย่างยิ่ง"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sisteminiz kritik bellek basıncı altında. Oyunu başlatmak kesinlikle önerilmez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hệ thống của bạn đang bị áp lực bộ nhớ nghiêm trọng. Khởi động trò chơi bị khuyến cáo mạnh mẽ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的系统正处于严重的内存压力下，强烈不建议启动游戏。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的系統正處於嚴重的記憶體壓力下，強烈不建議啟動遊戲。"
+          }
+        }
+      }
+    },
+    "game_launch.memory_pressure.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم اكتشاف ضغط الذاكرة"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hukommelsespresion opdaget"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherdruck erkannt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory Pressure Detected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presión de memoria detectada"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muistipaine havaittu"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pression mémoire détectée"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मेमोरी दबाव का पता चला"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressione sulla memoria rilevata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモリプレッシャーを検出"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모리 압력 감지"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minnetrykk oppdaget"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geheugendruk gedetecteerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykryto ciśnienie pamięci"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressão de memória detectada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обнаружено давление памяти"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minnestryck upptäckt"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ตรวจพบแรงกดดันหน่วยความจำ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bellek basıncı algılandı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phát hiện áp lực bộ nhớ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检测到内存压力"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偵測到記憶體壓力"
+          }
+        }
+      }
+    },
+    "game_launch.memory_pressure.warning_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نظامك يعاني من ضغطذاكرة. تشغيل اللعبة قد يسبب مشاكل في الأداء أو انهيارات."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit system har hukommelsespresion. Start af spillet kan forårsage ydeevneproblemer eller nedbrud."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihr System unterliegt einem Speicherdruck. Das Starten des Spiels kann zu Leistungsproblemen oder Abstürzen führen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your system is under memory pressure. Launching the game may cause performance issues or crashes."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Su sistema está bajo presión de memoria. Iniciar el juego puede causar problemas de rendimiento o caídas."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmässäsi on muistipaine. Pelin käynnistäminen voi aiheuttaa suorituskykyongelmia tai kaatumisia."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre système est sous pression mémoire. Le lancement du jeu peut provoquer des problèmes de performance ou des plantages."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपके सिस्टम में मेमोरी दबाव है। गेम लॉन्च करने से प्रदर्शन समस्याएं या क्रैश हो सकते हैं।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il sistema è sotto pressione sulla memoria. L'avvio del gioco può causare problemi di prestazione o crash."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムにメモリプレッシャーがあります。ゲームの起動により、パフォーマンスの問題やクラッシュが発生する可能性があります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템에 메모리 압력이 있습니다. 게임을 시작하면 성능 문제나 충돌이 발생할 수 있습니다."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemet ditt har minnetrykk. Å starte spillet kan forårsake ytelsesproblemer eller krasj."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uw systeem heeft geheugendruk. Het starten van het spel kan prestatieproblemen of crashes veroorzaken."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twój system jest pod ciśnieniem pamięci. Uruchomienie gry może spowodować problemy z wydajnością lub awarie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu sistema está sob pressão de memória. Iniciar o jogo pode causar problemas de desempenho ou travamentos."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша система испытывает давление памяти. Запуск игры может вызвать проблемы с производительностью или сбои."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditt system har minnestryck. Att starta spelet kan orsaka prestandaproblem eller krascher."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ระบบของคุณมีแรงกดดันหน่วยความจำ การเริ่มเกมอาจทำให้เกิดปัญหาด้านประสิทธิภาพหรือเกิดการขัดข้อง"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sisteminiz bellek basıncı altında. Oyunu başlatmak performans sorunlarına veya çökmelere neden olabilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hệ thống của bạn đang bị áp lực bộ nhớ. Khởi động trò chơi có thể gây ra vấn đề hiệu suất hoặc sự cố."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的系统正处于内存压力下，启动游戏可能会导致性能问题或崩溃。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的系統正處於記憶體壓力下，啟動遊戲可能會導致效能問題或崩潰。"
+          }
+        }
+      }
+    },
     "game.form.icon" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -71233,6 +71644,280 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "該選項用於是否在遊戲崩潰的時候啟用AI分析"
+          }
+        }
+      }
+    },
+    "settings.memory_pressure_warning.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحقق من ضغطذاكرة النظام قبل تشغيل الألعاب"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontroller systemets hukommelsespresion før du starter spil"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherdruck des Systems vor dem Starten von Spielen prüfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check system memory pressure before launching games"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificar la presión de memoria del sistema antes de iniciar juegos"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarkista järjestelmän muistipaine ennen pelien käynnistämistä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifier la pression mémoire du système avant de lancer des jeux"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "गेम लॉन्च करने से पहले सिस्टम मेमोरी दबाव की जांच करें"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controllare la pressione sulla memoria del sistema prima di avviare i giochi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ゲームを起動する前にシステムのメモリプレッシャーを確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "게임 시작 전 시스템 메모리 압력 확인"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontroller systemets minnetrykk før du starter spill"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controleer de geheugendruk van het systeem voordat u games start"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprawdź ciśnienie pamięci systemu przed uruchomieniem gier"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificar a pressão de memória do sistema antes de iniciar jogos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверьте давление памяти системы перед запуском игр"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontrollera systemets minnestryck innan du startar spel"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ตรวจสอบแรงกดดันหน่วยความจำของระบบก่อนเริ่มเกม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oyunları başlatmadan önce sistem bellek basıncını kontrol edin"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiểm tra áp lực bộ nhớ hệ thống trước khi khởi động trò chơi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动游戏前检查系统内存压力"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動遊戲前檢查系統記憶體壓力"
+          }
+        }
+      }
+    },
+    "settings.memory_pressure_warning.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحذير ضغط الذاكرة"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hukommelsespresionsadvarsel"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherdruck-Warnung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory Pressure Warning"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advertencia de presión de memoria"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muistipainevaroitus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avertissement de pression mémoire"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मेमोरी दबाव चेतावनी"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avviso pressione sulla memoria"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモリプレッシャー警告"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모리 압력 경고"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minnetrykkadvarsel"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geheugendrukwaarschuwing"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostrzeżenie o ciśnieniu pamięci"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de pressão de memória"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предупреждение о давлении памяти"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minnestrycksvarning"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "คำเตือนแรงกดดันหน่วยความจำ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bellek basıncı uyarısı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cảnh báo áp lực bộ nhớ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内存压力警告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體壓力警告"
           }
         }
       }


### PR DESCRIPTION
feat: 新增启动游戏的时候进行内存压力检测

## Summary by Sourcery

Add an optional pre-launch memory pressure check that can warn users and gate game startup when system memory is under stress.

New Features:
- Introduce a memory pressure checker that queries the OS for current pressure level and exposes it to the launcher.
- Add a user-facing alert flow that prompts whether to continue or cancel when elevated memory pressure is detected before game launch.
- Provide a settings toggle to enable or disable memory pressure warnings, persisted in user defaults.

Enhancements:
- Integrate the memory pressure alert into the main view presentation pipeline via a dedicated SwiftUI view modifier.