### PR TITLE
fix: pin SwiftFormat 0.61.1 binary path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,26 @@ jobs:
       # =========================
       - name: Install SwiftFormat 0.61.1
         run: |
-          curl -sL https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/swiftformat.zip -o swiftformat.zip
-          unzip -o swiftformat.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/swiftformat
-          swiftformat --version
+          set -euo pipefail
+          TOOL_DIR="${RUNNER_TEMP}/swiftformat-0.61.1"
+          mkdir -p "$TOOL_DIR"
+          curl -fsSL \
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/swiftformat.zip" \
+            -o "${TOOL_DIR}/swiftformat.zip"
+          unzip -o "${TOOL_DIR}/swiftformat.zip" -d "$TOOL_DIR"
+          chmod +x "${TOOL_DIR}/swiftformat"
+          echo "SWIFTFORMAT_BIN=${TOOL_DIR}/swiftformat" >> "$GITHUB_ENV"
+          VERSION="$("${TOOL_DIR}/swiftformat" --version)"
+          echo "SwiftFormat version: ${VERSION}"
+          if [[ "${VERSION}" != "0.61.1" ]]; then
+            echo "::error::Expected SwiftFormat 0.61.1, got ${VERSION}"
+            exit 1
+          fi
 
       - name: Run SwiftFormat lint
-        run: swiftformat . --swift-version 6.1 --lint
+        run: |
+          set -euo pipefail
+          "${SWIFTFORMAT_BIN}" . --swift-version 6.1 --lint
 
       # =========================
       # Code Rules Check


### PR DESCRIPTION
## Why
CI on `dev` is failing at `Run SwiftFormat lint` because the workflow downloads SwiftFormat 0.61.1 into `/usr/local/bin`, but the runner PATH resolves a newer preinstalled `0.62.1` first.

Evidence from failing runs:
- install step extracts 0.61.1
- `swiftformat --version` prints `0.62.1`
- lint fails with 0.62.x rules (`redundantSwiftUIGroup`, `wrapIfStatementBodies`, `indent`)

Last green CI used real 0.61.1. Local lint with 0.61.1 on current `dev` also passes (`0/527 files require formatting`).

## What changed
- Install SwiftFormat 0.61.1 into `$RUNNER_TEMP`
- Invoke it via absolute path (`$SWIFTFORMAT_BIN`)
- Fail fast if the resolved version is not exactly `0.61.1`

## Notes
- No application source changes
- Keeps existing project SwiftFormat policy for 0.61.1
- Avoids large reformat churn from accidentally running 0.62.1

## Summary by Sourcery

Pin the SwiftFormat 0.61.1 binary used in CI to avoid picking up newer preinstalled versions and to ensure consistent linting behavior.

CI:
- Update CI workflow to install SwiftFormat 0.61.1 into a dedicated runner temp directory and expose its absolute path via environment variable.
- Validate the installed SwiftFormat binary version in CI and use that pinned binary for linting.