### PR TITLE
fix: invoke pinned SwiftFormat via absolute path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           swiftformat --version
 
       - name: Run SwiftFormat lint
-        run: swiftformat . --swift-version 6.1 --lint
+        run: /usr/local/bin/swiftformat . --swift-version 6.1 --lint
 
       # =========================
       # Code Rules Check


### PR DESCRIPTION
## Why
CI on `dev` fails at `Run SwiftFormat lint` because the workflow installs SwiftFormat 0.61.1 into `/usr/local/bin`, but a bare `swiftformat` call resolves a newer preinstalled `0.62.1` from PATH first.

## What changed
One-line fix only:

```diff
- run: swiftformat . --swift-version 6.1 --lint
+ run: /usr/local/bin/swiftformat . --swift-version 6.1 --lint
```

This uses the binary installed by the existing install step, so PATH cannot pick the wrong version.

## Verification
Fork CI passed:
https://github.com/zeroy1024/Swift-Craft-Launcher/actions/runs/29646072264

Confirmed in that run:
- lint command: `/usr/local/bin/swiftformat . --swift-version 6.1 --lint`
- result: `0/527 files require formatting`
- SwiftLint / localization / unit tests also passed

## Notes
- No application source changes
- Install step left unchanged on purpose (minimal diff)

## Summary by Sourcery

CI:
- Update CI workflow to run SwiftFormat lint using /usr/local/bin/swiftformat to ensure the pinned version is used.