### PR TITLE
feat: 去除多余的根据文件id查询

### DIFF
--- a/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/suhang12332/CFModrinthAdapterKit.git",
       "state" : {
         "branch" : "release",
-        "revision" : "43097f89011104045fe2c268fbc70b2ff25b118a"
+        "revision" : "05560b233b26e3a38eb61c15cb9ddf365222c9ca"
       }
     },
     {

--- a/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/CurseForgeService+Dependencies.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/CurseForgeService+Dependencies.swift
@@ -31,9 +31,9 @@ extension CurseForgeService {
                     type: type,
                 )
             },
-            fetchVersionById: { versionID in
-                try await fetchVersionById(versionID)
-            },
+            // CurseForge dependencies carry no fileId (API limitation), so version-level
+            // lookup is not needed; resolution falls back to the first compatible version.
+            fetchVersionById: nil,
         )
         return await DependencyResolver.resolve(context)
     }
@@ -60,27 +60,6 @@ extension CurseForgeService {
                 selectedLoaders: selectedLoaders,
                 type: type,
             )
-        }
-    }
-
-    /// Fetches a version by ID, handling both CurseForge and Modrinth IDs.
-    private static func fetchVersionById(_ versionID: String) async throws -> ModrinthProjectDetailVersion {
-        let versionIdentifier = versionID.asProjectId
-        if versionIdentifier.isCurseForge {
-            let fileId = Int(versionID.replacingOccurrences(of: "cf-", with: "")) ?? 0
-            let normalizedProjectId = versionID.asProjectId.normalized
-            let (modId, _) = try normalizedProjectId.asProjectId.parseCurseForgeId()
-            let cfFile = try await fetchFileDetailThrowing(projectId: modId, fileId: fileId)
-            guard let convertedVersion = CFToModrinthAdapter.convertFile(cfFile, projectId: normalizedProjectId) else {
-                throw GlobalError.validation(
-                    i18nKey: "error.validation.version_convert_failed",
-                    level: .notification,
-                    message: "Failed to convert CurseForge file to Modrinth format for versionId=\(versionID)",
-                )
-            }
-            return convertedVersion
-        } else {
-            return try await ModrinthService.fetchProjectVersionThrowing(id: versionID)
         }
     }
 }

--- a/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/DependencyResolver.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/DependencyResolver.swift
@@ -21,7 +21,9 @@ enum DependencyResolver {
         let selectedVersions: [String]
         let selectedLoaders: [String]
         let fetchVersions: @Sendable (String) async throws -> [ModrinthProjectDetailVersion]
-        let fetchVersionById: @Sendable (String) async throws -> ModrinthProjectDetailVersion
+        /// Fetches an exact version by ID. Providers without version-level lookup
+        /// (e.g. CurseForge) leave this nil and fall back to the first compatible version.
+        let fetchVersionById: (@Sendable (String) async throws -> ModrinthProjectDetailVersion)?
     }
 
     /// Resolves missing dependencies for a project.
@@ -78,8 +80,8 @@ enum DependencyResolver {
                     guard let projectId = dep.projectId else { continue }
                     group.addTask {
                         do {
-                            if let versionId = dep.versionId {
-                                return try await context.fetchVersionById(versionId)
+                            if let versionId = dep.versionId, let fetchVersionById = context.fetchVersionById {
+                                return try await fetchVersionById(versionId)
                             } else {
                                 let depVersions = try await context.fetchVersions(projectId)
                                 guard let first = depVersions.first else {


### PR DESCRIPTION
feat: 去除多余的根据文件id查询

## Summary by Sourcery

Relax dependency resolution to handle providers that cannot look up versions by file ID and rely on compatible version selection instead.

Enhancements:
- Make dependency resolution context accept an optional version-by-ID fetcher to support providers without version-level lookup.
- Remove the CurseForge-specific version-by-ID lookup implementation and document fallback behavior for dependency resolution.