### PR TITLE
Dev

### DIFF
--- a/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftCraftLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/suhang12332/CFModrinthAdapterKit.git",
       "state" : {
         "branch" : "release",
-        "revision" : "05560b233b26e3a38eb61c15cb9ddf365222c9ca"
+        "revision" : "c430233f1a106220717cc5f17bc1d4c6b2b96689"
       }
     },
     {
@@ -16,7 +16,7 @@
       "location" : "https://github.com/suhang12332/MinecraftFriendsKit.git",
       "state" : {
         "branch" : "release",
-        "revision" : "9c274d5d18d483cfbec81a5b2aef4f8350d0f521"
+        "revision" : "74a9417e6793fa74abe29ba61f5f53184a24d33a"
       }
     },
     {
@@ -25,7 +25,7 @@
       "location" : "https://github.com/suhang12332/NSSkinRender.git",
       "state" : {
         "branch" : "release",
-        "revision" : "4443a5413b3638ef5141c7f0d0a8aff18d8925a6"
+        "revision" : "6854c0028731208e82d2de31dc5793fa74080c7d"
       }
     },
     {
@@ -70,7 +70,7 @@
       "location" : "https://github.com/suhang12332/SwiftMarkDownUI.git",
       "state" : {
         "branch" : "release",
-        "revision" : "51cfd39f0a153774c7aadae5df867e71ada02cad"
+        "revision" : "a82895291acadc90568ba9377d724ee727c57063"
       }
     },
     {

--- a/SwiftCraftLauncher/CommonFeature/Managers/App/AppCacheManager.swift
+++ b/SwiftCraftLauncher/CommonFeature/Managers/App/AppCacheManager.swift
@@ -13,18 +13,18 @@ class AppCacheManager {
 
     init() { }
 
-    private func fileURL(for namespace: String) throws -> URL {
+    private func fileURL(for namespace: String, in directory: URL = AppPaths.appCache) throws -> URL {
         do {
-            try FileManager.default.createDirectory(at: AppPaths.appCache, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         } catch {
             throw GlobalError.fileSystem(
                 i18nKey: "error.filesystem.cache_directory_creation_failed",
                 level: .notification,
-                message: "Failed to create cache directory at \(AppPaths.appCache.path): \(error.localizedDescription)",
+                message: "Failed to create cache directory at \(directory.path): \(error.localizedDescription)",
             )
         }
 
-        return AppPaths.appCache.appendingPathComponent("\(namespace).json")
+        return directory.appendingPathComponent("\(namespace).json")
     }
 
     /// Stores a codable value in the specified namespace.
@@ -33,14 +33,14 @@ class AppCacheManager {
     ///   - key: The cache key.
     ///   - value: The value to store.
     /// - Throws: A `GlobalError` when encoding or persistence fails.
-    func set(namespace: String, key: String, value: some Codable) throws {
+    func set(namespace: String, key: String, value: some Codable, directory: URL = AppPaths.appCache) throws {
         try queue.sync {
-            var nsDict = try loadNamespace(namespace)
+            var nsDict = try loadNamespace(namespace, directory: directory)
 
             do {
                 let data = try JSONEncoder().encode(value)
                 nsDict[key] = data
-                try saveNamespace(namespace, dict: nsDict)
+                try saveNamespace(namespace, dict: nsDict, directory: directory)
             } catch {
                 throw GlobalError.validation(
                     i18nKey: "error.validation.cache_data_encode_failed",
@@ -56,9 +56,9 @@ class AppCacheManager {
     ///   - namespace: The cache namespace.
     ///   - key: The cache key.
     ///   - value: The value to store.
-    func setSilently(namespace: String, key: String, value: some Codable) {
+    func setSilently(namespace: String, key: String, value: some Codable, directory: URL = AppPaths.appCache) {
         do {
-            try set(namespace: namespace, key: key, value: value)
+            try set(namespace: namespace, key: key, value: value, directory: directory)
         } catch {
             DIContainer.shared.core.errorHandler.handle(error)
         }
@@ -70,10 +70,10 @@ class AppCacheManager {
     ///   - key: The cache key.
     ///   - type: The expected value type.
     /// - Returns: The decoded value, or `nil` if not found or decoding fails.
-    func get<T: Codable>(namespace: String, key: String, as _: T.Type) -> T? {
+    func get<T: Codable>(namespace: String, key: String, as _: T.Type, directory: URL = AppPaths.appCache) -> T? {
         queue.sync {
             do {
-                let nsDict = try loadNamespace(namespace)
+                let nsDict = try loadNamespace(namespace, directory: directory)
                 guard let data = nsDict[key] else { return nil }
 
                 do {
@@ -93,8 +93,8 @@ class AppCacheManager {
         }
     }
 
-    private func loadNamespace(_ namespace: String) throws -> [String: Data] {
-        let url = try fileURL(for: namespace)
+    private func loadNamespace(_ namespace: String, directory: URL = AppPaths.appCache) throws -> [String: Data] {
+        let url = try fileURL(for: namespace, in: directory)
 
         guard FileManager.default.fileExists(atPath: url.path) else {
             return [:]
@@ -112,8 +112,8 @@ class AppCacheManager {
         }
     }
 
-    private func saveNamespace(_ namespace: String, dict: [String: Data]) throws {
-        let url = try fileURL(for: namespace)
+    private func saveNamespace(_ namespace: String, dict: [String: Data], directory: URL = AppPaths.appCache) throws {
+        let url = try fileURL(for: namespace, in: directory)
 
         do {
             let data = try JSONEncoder().encode(dict)

--- a/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/ModrinthService.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/Modrinth+CurseForge/ModrinthService.swift
@@ -10,12 +10,11 @@ import Foundation
 /// Provides access to the Modrinth API for Minecraft mod information and versions.
 enum ModrinthService {
     static func fetchVersionInfo(from version: String) async throws -> MinecraftVersionManifest {
-        let cacheKey = "version_info_\(version)"
-
         if let cachedVersionInfo: MinecraftVersionManifest = DIContainer.shared.core.appCacheManager.get(
-            namespace: "version_info",
-            key: cacheKey,
+            namespace: version,
+            key: "manifest",
             as: MinecraftVersionManifest.self,
+            directory: AppPaths.versionCache,
         ) {
             return cachedVersionInfo
         }
@@ -23,9 +22,10 @@ enum ModrinthService {
         let versionInfo = try await fetchVersionInfoThrowing(from: version)
 
         DIContainer.shared.core.appCacheManager.setSilently(
-            namespace: "version_info",
-            key: cacheKey,
+            namespace: version,
+            key: "manifest",
             value: versionInfo,
+            directory: AppPaths.versionCache,
         )
 
         return versionInfo

--- a/SwiftCraftLauncher/CommonFeature/Utilities/AppPaths.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/AppPaths.swift
@@ -159,6 +159,11 @@ extension AppPaths {
         appCache.appendingPathComponent("versions", isDirectory: true)
     }
 
+    /// The cache directory for loader profiles.
+    static var loaderCache: URL {
+        appCache.appendingPathComponent("loaders", isDirectory: true)
+    }
+
     /// The data directory for application-specific storage.
     static var dataDirectory: URL {
         launcherSupportDirectory.appendingPathComponent(AppConstants.DirectoryNames.data, isDirectory: true)

--- a/SwiftCraftLauncher/CommonFeature/Utilities/AppPaths.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/AppPaths.swift
@@ -154,6 +154,11 @@ extension AppPaths {
         return launcherSupportDirectory.appendingPathComponent("Cache", isDirectory: true)
     }
 
+    /// The cache directory for Minecraft version manifests.
+    static var versionCache: URL {
+        appCache.appendingPathComponent("versions", isDirectory: true)
+    }
+
     /// The data directory for application-specific storage.
     static var dataDirectory: URL {
         launcherSupportDirectory.appendingPathComponent(AppConstants.DirectoryNames.data, isDirectory: true)

--- a/SwiftCraftLauncher/GameFeature/Services/Loader/FabricLikeLoaderService.swift
+++ b/SwiftCraftLauncher/GameFeature/Services/Loader/FabricLikeLoaderService.swift
@@ -14,9 +14,14 @@ enum FabricLikeLoaderService {
     }
 
     static func fetchSpecificLoaderVersion(config: Config, for minecraftVersion: String, loaderVersion: String) async throws -> ModrinthLoader {
-        let cacheKey = "\(minecraftVersion)-\(loaderVersion)"
+        let namespace = "\(config.gameLoader.displayName)-\(minecraftVersion)-\(loaderVersion)"
 
-        if let cached = DIContainer.shared.core.appCacheManager.get(namespace: config.gameLoader.displayName, key: cacheKey, as: ModrinthLoader.self) {
+        if let cached = DIContainer.shared.core.appCacheManager.get(
+            namespace: namespace,
+            key: "profile",
+            as: ModrinthLoader.self,
+            directory: AppPaths.loaderCache,
+        ) {
             return cached
         }
 
@@ -26,7 +31,12 @@ enum FabricLikeLoaderService {
         var result = try JSONDecoder().decode(ModrinthLoader.self, from: data)
         result = CommonService.processGameVersionPlaceholders(loader: result, gameVersion: minecraftVersion)
         result.version = loaderVersion
-        DIContainer.shared.core.appCacheManager.setSilently(namespace: config.gameLoader.displayName, key: cacheKey, value: result)
+        DIContainer.shared.core.appCacheManager.setSilently(
+            namespace: namespace,
+            key: "profile",
+            value: result,
+            directory: AppPaths.loaderCache,
+        )
 
         return result
     }

--- a/SwiftCraftLauncher/GameFeature/Services/Loader/ForgeLikeLoaderService.swift
+++ b/SwiftCraftLauncher/GameFeature/Services/Loader/ForgeLikeLoaderService.swift
@@ -28,9 +28,14 @@ enum ForgeLikeLoaderService {
     }
 
     static func fetchSpecificProfile(config: Config, for minecraftVersion: String, loaderVersion: String) async throws -> ModrinthLoader {
-        let cacheKey = "\(minecraftVersion)-\(loaderVersion)"
+        let namespace = "\(config.gameLoader.displayName)-\(minecraftVersion)-\(loaderVersion)"
 
-        if let cached = DIContainer.shared.core.appCacheManager.get(namespace: config.gameLoader.displayName, key: cacheKey, as: ModrinthLoader.self) {
+        if let cached = DIContainer.shared.core.appCacheManager.get(
+            namespace: namespace,
+            key: "profile",
+            as: ModrinthLoader.self,
+            directory: AppPaths.loaderCache,
+        ) {
             return cached
         }
 
@@ -40,7 +45,12 @@ enum ForgeLikeLoaderService {
         var result = try JSONDecoder().decode(ModrinthLoader.self, from: data)
         result = CommonService.processGameVersionPlaceholders(loader: result, gameVersion: minecraftVersion)
         result.version = loaderVersion
-        DIContainer.shared.core.appCacheManager.setSilently(namespace: config.gameLoader.displayName, key: cacheKey, value: result)
+        DIContainer.shared.core.appCacheManager.setSilently(
+            namespace: namespace,
+            key: "profile",
+            value: result,
+            directory: AppPaths.loaderCache,
+        )
 
         return result
     }


### PR DESCRIPTION
## Summary by Sourcery

Refine application caching to support dedicated cache directories and more granular namespaces for Modrinth version and loader data.

Enhancements:
- Allow AppCacheManager operations to target configurable cache directories instead of a single global cache location.
- Introduce dedicated cache paths for Minecraft version manifests and loader profiles via AppPaths utilities.
- Update Modrinth and loader services to use version- and loader-specific namespaces, keys, and directories for their cached data.