### PR TITLE
feat: 增加资源详情页 HTML 转 Markdown 逻辑及修复图片大小问题

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Views/Components/CommonMenuPicker.swift
+++ b/SwiftCraftLauncher/CommonFeature/Views/Components/CommonMenuPicker.swift
@@ -65,6 +65,14 @@ private struct ConditionalLabelsHidden: ViewModifier {
 
 private struct FlexibleButtonSizingModifier: ViewModifier {
     func body(content: Content) -> some View {
-        content
+        #if compiler(>=6.2)
+            if #available(macOS 26, *) {
+                content.buttonSizing(.flexible)
+            } else {
+                content
+            }
+        #else
+            content
+        #endif
     }
 }

--- a/SwiftCraftLauncher/CommonFeature/Views/Components/CommonMenuPicker.swift
+++ b/SwiftCraftLauncher/CommonFeature/Views/Components/CommonMenuPicker.swift
@@ -65,10 +65,6 @@ private struct ConditionalLabelsHidden: ViewModifier {
 
 private struct FlexibleButtonSizingModifier: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content.buttonSizing(.flexible)
-        } else {
-            content
-        }
+        content
     }
 }

--- a/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLTestMod.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLTestMod.swift
@@ -1,0 +1,81 @@
+//
+//  HTMLTestMod.swift
+//  ResourceFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+
+#if DEBUG
+/// A local-only project used to exercise the HTML description renderer.
+enum HTMLTestMod {
+    static let projectId = "swift-craft-launcher-html-test-mod"
+
+    static let project = ModrinthProject(
+        projectId: projectId,
+        projectType: "mod",
+        slug: "html-test-mod",
+        author: "Swift Craft Launcher",
+        title: "HTML Test Mod",
+        description: "HTML renderer test project",
+        categories: ["fabric", "utility"],
+        displayCategories: ["fabric", "utility"],
+        versions: ["1.21"],
+        downloads: 0,
+        follows: 0,
+        iconUrl: nil,
+        license: "MIT",
+        clientSide: "required",
+        serverSide: "unsupported",
+        fileName: nil,
+    )
+
+    static let detail = ModrinthProjectDetail(
+        slug: project.slug,
+        title: project.title,
+        description: project.description,
+        categories: project.categories,
+        clientSide: project.clientSide,
+        serverSide: project.serverSide,
+        body: """
+        <h1>HTML Test Mod</h1>
+        <p>This is <strong>bold</strong>, <b>also bold</b>, <em>italic</em>, <i>also italic</i>, <s>struck</s>, and <del>deleted</del>.</p>
+        <p>Read the <a href="https://example.com/project">project page</a> or press <button data-url="https://example.com/download">Download</button>.</p>
+        <p>Inline image: <img src="https://example.com/icon.png" alt="Test icon" /></p>
+        <div>Block one<br />Block two</div>
+        <hr />
+        <blockquote>A quoted line with <code>inlineCode()</code>.</blockquote>
+        <pre><code>public func testMod() {
+            print("hello")
+        }</code></pre>
+        <ul><li>Fabric</li><li>Quilt</li></ul>
+        <ol><li>Install the mod</li><li>Launch Minecraft</li></ol>
+        <table><thead><tr><th>Loader</th><th>Version</th></tr></thead><tbody><tr><td>Fabric</td><td>1.21</td></tr></tbody></table>
+        <video src="https://example.com/demo.mp4" title="Demo video"></video>
+        <audio><source src="https://example.com/demo.mp3" /></audio>
+        <svg aria-label="Test icon"><path d="M0 0" /></svg>
+        <details><summary>Advanced details</summary><p>Extra information.</p></details>
+        """,
+        additionalCategories: ["fabric", "utility"],
+        issuesUrl: nil,
+        sourceUrl: "https://example.com/html-test-mod",
+        wikiUrl: nil,
+        discordUrl: nil,
+        projectType: "mod",
+        downloads: 0,
+        iconUrl: nil,
+        id: projectId,
+        team: "Swift Craft Launcher",
+        published: Date(timeIntervalSince1970: 0),
+        updated: Date(timeIntervalSince1970: 0),
+        followers: 0,
+        license: nil,
+        versions: ["1.21"],
+        gameVersions: ["1.21"],
+        loaders: ["fabric"],
+        type: "mod",
+        fileName: nil,
+    )
+}
+#endif

--- a/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLTestMod.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLTestMod.swift
@@ -8,74 +8,74 @@
 import Foundation
 
 #if DEBUG
-/// A local-only project used to exercise the HTML description renderer.
-enum HTMLTestMod {
-    static let projectId = "swift-craft-launcher-html-test-mod"
+    /// A local-only project used to exercise the HTML description renderer.
+    enum HTMLTestMod {
+        static let projectId = "swift-craft-launcher-html-test-mod"
 
-    static let project = ModrinthProject(
-        projectId: projectId,
-        projectType: "mod",
-        slug: "html-test-mod",
-        author: "Swift Craft Launcher",
-        title: "HTML Test Mod",
-        description: "HTML renderer test project",
-        categories: ["fabric", "utility"],
-        displayCategories: ["fabric", "utility"],
-        versions: ["1.21"],
-        downloads: 0,
-        follows: 0,
-        iconUrl: nil,
-        license: "MIT",
-        clientSide: "required",
-        serverSide: "unsupported",
-        fileName: nil,
-    )
+        static let project = ModrinthProject(
+            projectId: projectId,
+            projectType: "mod",
+            slug: "html-test-mod",
+            author: "Swift Craft Launcher",
+            title: "HTML Test Mod",
+            description: "HTML renderer test project",
+            categories: ["fabric", "utility"],
+            displayCategories: ["fabric", "utility"],
+            versions: ["1.21"],
+            downloads: 0,
+            follows: 0,
+            iconUrl: nil,
+            license: "MIT",
+            clientSide: "required",
+            serverSide: "unsupported",
+            fileName: nil,
+        )
 
-    static let detail = ModrinthProjectDetail(
-        slug: project.slug,
-        title: project.title,
-        description: project.description,
-        categories: project.categories,
-        clientSide: project.clientSide,
-        serverSide: project.serverSide,
-        body: """
-        <h1>HTML Test Mod</h1>
-        <p>This is <strong>bold</strong>, <b>also bold</b>, <em>italic</em>, <i>also italic</i>, <s>struck</s>, and <del>deleted</del>.</p>
-        <p>Read the <a href="https://example.com/project">project page</a> or press <button data-url="https://example.com/download">Download</button>.</p>
-        <p>Inline image: <img src="https://example.com/icon.png" alt="Test icon" /></p>
-        <div>Block one<br />Block two</div>
-        <hr />
-        <blockquote>A quoted line with <code>inlineCode()</code>.</blockquote>
-        <pre><code>public func testMod() {
-            print("hello")
-        }</code></pre>
-        <ul><li>Fabric</li><li>Quilt</li></ul>
-        <ol><li>Install the mod</li><li>Launch Minecraft</li></ol>
-        <table><thead><tr><th>Loader</th><th>Version</th></tr></thead><tbody><tr><td>Fabric</td><td>1.21</td></tr></tbody></table>
-        <video src="https://example.com/demo.mp4" title="Demo video"></video>
-        <audio><source src="https://example.com/demo.mp3" /></audio>
-        <svg aria-label="Test icon"><path d="M0 0" /></svg>
-        <details><summary>Advanced details</summary><p>Extra information.</p></details>
-        """,
-        additionalCategories: ["fabric", "utility"],
-        issuesUrl: nil,
-        sourceUrl: "https://example.com/html-test-mod",
-        wikiUrl: nil,
-        discordUrl: nil,
-        projectType: "mod",
-        downloads: 0,
-        iconUrl: nil,
-        id: projectId,
-        team: "Swift Craft Launcher",
-        published: Date(timeIntervalSince1970: 0),
-        updated: Date(timeIntervalSince1970: 0),
-        followers: 0,
-        license: nil,
-        versions: ["1.21"],
-        gameVersions: ["1.21"],
-        loaders: ["fabric"],
-        type: "mod",
-        fileName: nil,
-    )
-}
+        static let detail = ModrinthProjectDetail(
+            slug: project.slug,
+            title: project.title,
+            description: project.description,
+            categories: project.categories,
+            clientSide: project.clientSide,
+            serverSide: project.serverSide,
+            body: """
+            <h1>HTML Test Mod</h1>
+            <p>This is <strong>bold</strong>, <b>also bold</b>, <em>italic</em>, <i>also italic</i>, <s>struck</s>, and <del>deleted</del>.</p>
+            <p>Read the <a href="https://example.com/project">project page</a> or press <button data-url="https://example.com/download">Download</button>.</p>
+            <p>Inline image: <img src="https://example.com/icon.png" alt="Test icon" /></p>
+            <div>Block one<br />Block two</div>
+            <hr />
+            <blockquote>A quoted line with <code>inlineCode()</code>.</blockquote>
+            <pre><code>public func testMod() {
+                print("hello")
+            }</code></pre>
+            <ul><li>Fabric</li><li>Quilt</li></ul>
+            <ol><li>Install the mod</li><li>Launch Minecraft</li></ol>
+            <table><thead><tr><th>Loader</th><th>Version</th></tr></thead><tbody><tr><td>Fabric</td><td>1.21</td></tr></tbody></table>
+            <video src="https://example.com/demo.mp4" title="Demo video"></video>
+            <audio><source src="https://example.com/demo.mp3" /></audio>
+            <svg aria-label="Test icon"><path d="M0 0" /></svg>
+            <details><summary>Advanced details</summary><p>Extra information.</p></details>
+            """,
+            additionalCategories: ["fabric", "utility"],
+            issuesUrl: nil,
+            sourceUrl: "https://example.com/html-test-mod",
+            wikiUrl: nil,
+            discordUrl: nil,
+            projectType: "mod",
+            downloads: 0,
+            iconUrl: nil,
+            id: projectId,
+            team: "Swift Craft Launcher",
+            published: Date(timeIntervalSince1970: 0),
+            updated: Date(timeIntervalSince1970: 0),
+            followers: 0,
+            license: nil,
+            versions: ["1.21"],
+            gameVersions: ["1.21"],
+            loaders: ["fabric"],
+            type: "mod",
+            fileName: nil,
+        )
+    }
 #endif

--- a/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLToMarkdownConverter.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLToMarkdownConverter.swift
@@ -1,0 +1,419 @@
+//
+//  HTMLToMarkdownConverter.swift
+//  ResourceFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+
+/// Converts the small, safe HTML dialect used by mod descriptions to Markdown.
+///
+/// This intentionally supports a whitelist instead of trying to implement a
+/// browser. Unsupported elements keep their textual content and executable
+/// elements are discarded.
+enum HTMLToMarkdownConverter {
+    fileprivate static let voidTags: Set<String> = [
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr",
+    ]
+
+    private static let ignoredTags: Set<String> = ["head", "script", "style", "template"]
+
+    static func convert(_ html: String) -> String {
+        let root = HTMLNode(tag: "root")
+        HTMLParser.parse(html, into: root)
+
+        let markdown = renderChildren(of: root)
+        return normalize(markdown)
+    }
+
+    static func convertIfNeeded(_ content: String) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<\s*/?\s*(?:a|article|audio|b|blockquote|br|button|code|del|details|div|em|figure|h[1-6]|hr|i|img|li|ol|p|pre|s|section|strong|svg|table|td|th|tr|ul|video)(?:\s|/?>)"#,
+            options: [.caseInsensitive],
+        ) else {
+            return content
+        }
+
+        let range = NSRange(content.startIndex..., in: content)
+        return regex.firstMatch(in: content, range: range) == nil ? content : convert(content)
+    }
+
+    private static func renderChildren(of node: HTMLNode) -> String {
+        node.children.map(render).joined()
+    }
+
+    private static func render(_ node: HTMLNode) -> String {
+        guard !ignoredTags.contains(node.tag) else { return "" }
+
+        switch node.tag {
+        case "text":
+            return decodeEntities(node.text)
+        case "root", "body", "html", "span":
+            return renderChildren(of: node)
+        case "p", "div", "section", "article", "main", "header", "footer", "center", "figure":
+            return block(renderChildren(of: node))
+        case let tag where tag.count == 2 && tag.first == "h" && (1...6).contains(Int(tag.dropFirst()) ?? 0):
+            let level = Int(tag.dropFirst()) ?? 1
+            return block("\(String(repeating: "#", count: level)) \(renderChildren(of: node))")
+        case "br":
+            return "\n"
+        case "hr":
+            return "\n\n---\n\n"
+        case "strong", "b":
+            return wrap(renderChildren(of: node), prefix: "**", suffix: "**")
+        case "em", "i":
+            return wrap(renderChildren(of: node), prefix: "*", suffix: "*")
+        case "s", "del":
+            return wrap(renderChildren(of: node), prefix: "~~", suffix: "~~")
+        case "code":
+            return wrap(renderChildren(of: node), prefix: "`", suffix: "`")
+        case "pre":
+            let code = rawText(of: node).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !code.isEmpty else { return "" }
+            return block("```\n\(code)\n```")
+        case "a", "button":
+            return renderAction(node)
+        case "img":
+            return renderImage(node)
+        case "video", "audio":
+            return renderMedia(node)
+        case "svg":
+            return renderSVG(node)
+        case "ul":
+            return renderList(node, ordered: false)
+        case "ol":
+            return renderList(node, ordered: true)
+        case "li":
+            return renderChildren(of: node)
+        case "blockquote":
+            let content = normalize(renderChildren(of: node))
+            return block(content.split(separator: "\n", omittingEmptySubsequences: false).map { "> \($0)" }.joined(separator: "\n"))
+        case "table":
+            return renderTable(node)
+        case "thead", "tbody", "tfoot", "tr", "th", "td", "source":
+            return renderChildren(of: node)
+        default:
+            return renderChildren(of: node)
+        }
+    }
+
+    private static func renderAction(_ node: HTMLNode) -> String {
+        let title = normalizeInline(renderChildren(of: node))
+        guard !title.isEmpty else { return "" }
+
+        let url = node.attributes["href"]
+            ?? node.attributes["data-url"]
+            ?? extractURL(from: node.attributes["onclick"])
+
+        guard let url, isSafeURL(url) else {
+            return node.tag == "button" ? wrap(title, prefix: "**", suffix: "**") : title
+        }
+
+        return "[\(title)](\(escapeMarkdownURL(url)))"
+    }
+
+    private static func renderImage(_ node: HTMLNode) -> String {
+        guard let source = node.attributes["src"], isSafeURL(source) else {
+            return normalizeInline(node.attributes["alt"] ?? "")
+        }
+
+        let alt = normalizeInline(node.attributes["alt"] ?? "image")
+        return "![\(alt)](\(escapeMarkdownURL(source)))"
+    }
+
+    private static func renderMedia(_ node: HTMLNode) -> String {
+        let source = node.attributes["src"] ?? findSource(in: node)
+        guard let source, isSafeURL(source) else {
+            return normalizeInline(renderChildren(of: node))
+        }
+
+        let label = node.attributes["title"]
+            ?? (node.tag == "video" ? "▶ Video" : "🔊 Audio")
+        return "[\(normalizeInline(label))](\(escapeMarkdownURL(source)))"
+    }
+
+    private static func renderSVG(_ node: HTMLNode) -> String {
+        let label = node.attributes["aria-label"]
+            ?? node.attributes["title"]
+            ?? normalizeInline(renderChildren(of: node))
+
+        return label.isEmpty ? "[SVG]" : "[\(label)]"
+    }
+
+    private static func renderList(_ node: HTMLNode, ordered: Bool) -> String {
+        var index = 1
+        let items = node.children.filter { $0.tag == "li" }.map { item -> String in
+            let contentLines = normalize(renderChildren(of: item))
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+            guard let firstLine = contentLines.first else {
+                defer { index += 1 }
+                return ""
+            }
+
+            let nestedLines = contentLines.dropFirst().map { "  \($0)" }
+            defer { index += 1 }
+            let marker = ordered ? "\(index)." : "-"
+            return (["\(marker) \(firstLine)"] + nestedLines).joined(separator: "\n")
+        }
+
+        return block(items.joined(separator: "\n"))
+    }
+
+    private static func renderTable(_ node: HTMLNode) -> String {
+        let rows = tableRows(in: node)
+        guard let firstRow = rows.first, !firstRow.isEmpty else { return "" }
+
+        let columnCount = rows.map(\.count).max() ?? firstRow.count
+        let normalizedRows = rows.map { row in
+            row + Array(repeating: "", count: max(0, columnCount - row.count))
+        }
+        let header = normalizedRows[0].map { escapeTableCell(normalizeInline($0)) }
+        let separator = Array(repeating: "---", count: columnCount)
+        let body = normalizedRows.dropFirst().map { row in
+            "| " + row.map { escapeTableCell(normalizeInline($0)) }.joined(separator: " | ") + " |"
+        }
+
+        return block(([
+            "| " + header.joined(separator: " | ") + " |",
+            "| " + separator.joined(separator: " | ") + " |",
+        ] + body).joined(separator: "\n"))
+    }
+
+    private static func tableRows(in node: HTMLNode) -> [[String]] {
+        if node.tag == "tr" {
+            return [node.children.filter { $0.tag == "th" || $0.tag == "td" }.map { renderChildren(of: $0) }]
+        }
+        return node.children.flatMap { tableRows(in: $0) }
+    }
+
+    private static func findSource(in node: HTMLNode) -> String? {
+        for child in node.children {
+            if child.tag == "source", let source = child.attributes["src"] {
+                return source
+            }
+            if let source = findSource(in: child) {
+                return source
+            }
+        }
+        return nil
+    }
+
+    private static func rawText(of node: HTMLNode) -> String {
+        let text = node.children.map { child in
+            child.tag == "text" ? child.text : rawText(of: child)
+        }
+        return text.joined()
+    }
+
+    private static func extractURL(from onclick: String?) -> String? {
+        guard let onclick else { return nil }
+        let patterns = [
+            #"(?:location(?:\.href)?|window\.open)\s*\(?\s*['\"]([^'\"]+)['\"]"#,
+            #"(?:url|href)\s*[:=]\s*['\"]([^'\"]+)['\"]"#,
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(onclick.startIndex..., in: onclick)
+            if let match = regex.firstMatch(in: onclick, range: range), let urlRange = Range(match.range(at: 1), in: onclick) {
+                return String(onclick[urlRange])
+            }
+        }
+        return nil
+    }
+
+    private static func isSafeURL(_ value: String) -> Bool {
+        guard let url = URL(string: value), let scheme = url.scheme?.lowercased() else { return false }
+        return ["http", "https", "mailto", "minecraft"].contains(scheme)
+    }
+
+    private static func escapeMarkdownURL(_ value: String) -> String {
+        value.replacingOccurrences(of: ")", with: "%29")
+    }
+
+    private static func block(_ value: String) -> String {
+        let content = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return content.isEmpty ? "" : "\n\n\(content)\n\n"
+    }
+
+    private static func wrap(_ value: String, prefix: String, suffix: String) -> String {
+        let content = normalizeInline(value)
+        return content.isEmpty ? "" : "\(prefix)\(content)\(suffix)"
+    }
+
+    private static func normalize(_ value: String) -> String {
+        var result = value.replacingOccurrences(of: "\r\n", with: "\n")
+        result = result.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                let preservesMarkdownIndentation = line.hasPrefix("  ")
+                    && (trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ "))
+                return preservesMarkdownIndentation ? String(line).trimmingCharacters(in: .newlines) : trimmed
+            }
+            .joined(separator: "\n")
+        while result.contains("\n\n\n") {
+            result = result.replacingOccurrences(of: "\n\n\n", with: "\n\n")
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func normalizeInline(_ value: String) -> String {
+        decodeEntities(value)
+            .replacingOccurrences(of: "\n", with: " ")
+            .split { $0 == " " || $0 == "\t" }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func decodeEntities(_ value: String) -> String {
+        let entities = [
+            "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": "\"", "&#39;": "'", "&apos;": "'", "&nbsp;": " ",
+        ]
+        return entities.reduce(value) { result, entity in
+            result.replacingOccurrences(of: entity.key, with: entity.value)
+        }
+    }
+
+    private static func escapeTableCell(_ value: String) -> String {
+        value.replacingOccurrences(of: "|", with: "\\|")
+    }
+}
+
+private final class HTMLNode {
+    let tag: String
+    var attributes: [String: String] = [:]
+    var children: [HTMLNode] = []
+    var text = ""
+
+    init(tag: String) {
+        self.tag = tag
+    }
+}
+
+private enum HTMLParser {
+    static func parse(_ html: String, into root: HTMLNode) {
+        var stack = [root]
+        var cursor = html.startIndex
+
+        while cursor < html.endIndex {
+            guard let tagStart = html[cursor...].firstIndex(of: "<") else {
+                appendText(String(html[cursor...]), to: stack.last)
+                break
+            }
+
+            if tagStart > cursor {
+                appendText(String(html[cursor..<tagStart]), to: stack.last)
+            }
+
+            if html[tagStart...].hasPrefix("<!--"), let commentEnd = html[tagStart...].range(of: "-->")?.upperBound {
+                cursor = commentEnd
+                continue
+            }
+
+            guard let tagEnd = findTagEnd(in: html, from: tagStart) else {
+                appendText(String(html[tagStart...]), to: stack.last)
+                break
+            }
+
+            let rawTag = String(html[html.index(after: tagStart)..<tagEnd])
+            cursor = html.index(after: tagEnd)
+
+            if rawTag.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("!") {
+                continue
+            }
+
+            if rawTag.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/") {
+                let closingTagName = rawTag.trimmingCharacters(in: .whitespacesAndNewlines).dropFirst()
+                let closingTag = closingTagName.split { $0.isWhitespace }.first.map(String.init)?.lowercased()
+                if let closingTag, let index = stack.lastIndex(where: { $0.tag == closingTag }), index > 0 {
+                    stack.removeSubrange(index..<stack.count)
+                }
+                continue
+            }
+
+            let parsed = parseOpeningTag(rawTag)
+            guard let tag = parsed.tag else { continue }
+
+            let node = HTMLNode(tag: tag)
+            node.attributes = parsed.attributes
+            stack[stack.count - 1].children.append(node)
+
+            if !parsed.isSelfClosing, !HTMLToMarkdownConverter.voidTags.contains(tag) {
+                stack.append(node)
+            }
+        }
+    }
+
+    private static func appendText(_ text: String, to node: HTMLNode?) {
+        guard let node, !text.isEmpty else { return }
+        let child = HTMLNode(tag: "text")
+        child.text = text
+        node.children.append(child)
+    }
+
+    private static func findTagEnd(in html: String, from start: String.Index) -> String.Index? {
+        var quote: Character?
+        var cursor = html.index(after: start)
+        while cursor < html.endIndex {
+            let character = html[cursor]
+            if character == "'" || character == "\"" {
+                quote = quote == character ? nil : (quote == nil ? character : quote)
+            } else if character == ">" && quote == nil {
+                return cursor
+            }
+            cursor = html.index(after: cursor)
+        }
+        return nil
+    }
+
+    private static func parseOpeningTag(_ rawTag: String) -> (tag: String?, attributes: [String: String], isSelfClosing: Bool) {
+        var value = rawTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isSelfClosing = value.hasSuffix("/")
+        if isSelfClosing {
+            value.removeLast()
+            value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let name = value.prefix { !$0.isWhitespace }
+        guard !name.isEmpty else { return (nil, [:], isSelfClosing) }
+
+        var attributes: [String: String] = [:]
+        var cursor = value.index(value.startIndex, offsetBy: name.count)
+
+        while cursor < value.endIndex {
+            while cursor < value.endIndex, value[cursor].isWhitespace { cursor = value.index(after: cursor) }
+            guard cursor < value.endIndex else { break }
+
+            let keyStart = cursor
+            while cursor < value.endIndex, !value[cursor].isWhitespace, value[cursor] != "=" {
+                cursor = value.index(after: cursor)
+            }
+            let key = String(value[keyStart..<cursor]).lowercased()
+            while cursor < value.endIndex, value[cursor].isWhitespace { cursor = value.index(after: cursor) }
+
+            var attributeValue = ""
+            if cursor < value.endIndex, value[cursor] == "=" {
+                cursor = value.index(after: cursor)
+                while cursor < value.endIndex, value[cursor].isWhitespace { cursor = value.index(after: cursor) }
+                if cursor < value.endIndex, value[cursor] == "'" || value[cursor] == "\"" {
+                    let quote = value[cursor]
+                    cursor = value.index(after: cursor)
+                    let valueStart = cursor
+                    while cursor < value.endIndex, value[cursor] != quote { cursor = value.index(after: cursor) }
+                    attributeValue = String(value[valueStart..<cursor])
+                    if cursor < value.endIndex { cursor = value.index(after: cursor) }
+                } else {
+                    let valueStart = cursor
+                    while cursor < value.endIndex, !value[cursor].isWhitespace { cursor = value.index(after: cursor) }
+                    attributeValue = String(value[valueStart..<cursor])
+                }
+            }
+
+            if !key.isEmpty { attributes[key] = attributeValue }
+        }
+
+        return (String(name).lowercased(), attributes, isSelfClosing)
+    }
+}

--- a/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLToMarkdownConverter.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Utilities/HTMLToMarkdownConverter.swift
@@ -13,13 +13,25 @@ import Foundation
 /// browser. Unsupported elements keep their textual content and executable
 /// elements are discarded.
 enum HTMLToMarkdownConverter {
+    private static let maxInputLength = 1_000_000
+    fileprivate static let maxParserDepth = 128
+
     fileprivate static let voidTags: Set<String> = [
         "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr",
     ]
 
     private static let ignoredTags: Set<String> = ["head", "script", "style", "template"]
+    private static let supportedTags: Set<String> = [
+        "a", "article", "audio", "b", "blockquote", "body", "br", "button", "center", "code", "del", "details", "div", "em", "figcaption", "figure", "footer",
+        "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hr", "html", "i", "img", "li", "main", "ol", "p", "pre", "s", "script", "section",
+        "source", "span", "strong", "style", "svg", "table", "tbody", "td", "tfoot", "th", "thead", "template", "tr", "ul", "video",
+    ]
 
     static func convert(_ html: String) -> String {
+        guard html.utf8.count <= maxInputLength else {
+            return html
+        }
+
         let root = HTMLNode(tag: "root")
         HTMLParser.parse(html, into: root)
 
@@ -28,15 +40,22 @@ enum HTMLToMarkdownConverter {
     }
 
     static func convertIfNeeded(_ content: String) -> String {
+        guard content.utf8.count <= maxInputLength else {
+            return content
+        }
         guard let regex = try? NSRegularExpression(
-            pattern: #"<\s*/?\s*(?:a|article|audio|b|blockquote|br|button|code|del|details|div|em|figure|h[1-6]|hr|i|img|li|ol|p|pre|s|section|strong|svg|table|td|th|tr|ul|video)(?:\s|/?>)"#,
+            pattern: #"<\s*/?\s*([A-Za-z][A-Za-z0-9]*)\b"#,
             options: [.caseInsensitive],
         ) else {
             return content
         }
 
         let range = NSRange(content.startIndex..., in: content)
-        return regex.firstMatch(in: content, range: range) == nil ? content : convert(content)
+        guard let match = regex.firstMatch(in: content, range: range),
+              let tagRange = Range(match.range(at: 1), in: content) else {
+            return content
+        }
+        return supportedTags.contains(content[tagRange].lowercased()) ? convert(content) : content
     }
 
     private static func renderChildren(of node: HTMLNode) -> String {
@@ -53,7 +72,7 @@ enum HTMLToMarkdownConverter {
             return renderChildren(of: node)
         case "p", "div", "section", "article", "main", "header", "footer", "center", "figure":
             return block(renderChildren(of: node))
-        case let tag where tag.count == 2 && tag.first == "h" && (1...6).contains(Int(tag.dropFirst()) ?? 0):
+        case let tag where tag.count == 2 && tag.first == "h" && (1 ... 6).contains(Int(tag.dropFirst()) ?? 0):
             let level = Int(tag.dropFirst()) ?? 1
             return block("\(String(repeating: "#", count: level)) \(renderChildren(of: node))")
         case "br":
@@ -304,7 +323,7 @@ private enum HTMLParser {
             }
 
             if tagStart > cursor {
-                appendText(String(html[cursor..<tagStart]), to: stack.last)
+                appendText(String(html[cursor ..< tagStart]), to: stack.last)
             }
 
             if html[tagStart...].hasPrefix("<!--"), let commentEnd = html[tagStart...].range(of: "-->")?.upperBound {
@@ -317,7 +336,7 @@ private enum HTMLParser {
                 break
             }
 
-            let rawTag = String(html[html.index(after: tagStart)..<tagEnd])
+            let rawTag = String(html[html.index(after: tagStart) ..< tagEnd])
             cursor = html.index(after: tagEnd)
 
             if rawTag.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("!") {
@@ -328,7 +347,7 @@ private enum HTMLParser {
                 let closingTagName = rawTag.trimmingCharacters(in: .whitespacesAndNewlines).dropFirst()
                 let closingTag = closingTagName.split { $0.isWhitespace }.first.map(String.init)?.lowercased()
                 if let closingTag, let index = stack.lastIndex(where: { $0.tag == closingTag }), index > 0 {
-                    stack.removeSubrange(index..<stack.count)
+                    stack.removeSubrange(index ..< stack.count)
                 }
                 continue
             }
@@ -340,7 +359,9 @@ private enum HTMLParser {
             node.attributes = parsed.attributes
             stack[stack.count - 1].children.append(node)
 
-            if !parsed.isSelfClosing, !HTMLToMarkdownConverter.voidTags.contains(tag) {
+            if !parsed.isSelfClosing,
+               !HTMLToMarkdownConverter.voidTags.contains(tag),
+               stack.count < HTMLToMarkdownConverter.maxParserDepth {
                 stack.append(node)
             }
         }
@@ -360,7 +381,7 @@ private enum HTMLParser {
             let character = html[cursor]
             if character == "'" || character == "\"" {
                 quote = quote == character ? nil : (quote == nil ? character : quote)
-            } else if character == ">" && quote == nil {
+            } else if character == ">", quote == nil {
                 return cursor
             }
             cursor = html.index(after: cursor)
@@ -390,7 +411,7 @@ private enum HTMLParser {
             while cursor < value.endIndex, !value[cursor].isWhitespace, value[cursor] != "=" {
                 cursor = value.index(after: cursor)
             }
-            let key = String(value[keyStart..<cursor]).lowercased()
+            let key = String(value[keyStart ..< cursor]).lowercased()
             while cursor < value.endIndex, value[cursor].isWhitespace { cursor = value.index(after: cursor) }
 
             var attributeValue = ""
@@ -402,16 +423,20 @@ private enum HTMLParser {
                     cursor = value.index(after: cursor)
                     let valueStart = cursor
                     while cursor < value.endIndex, value[cursor] != quote { cursor = value.index(after: cursor) }
-                    attributeValue = String(value[valueStart..<cursor])
-                    if cursor < value.endIndex { cursor = value.index(after: cursor) }
+                    attributeValue = String(value[valueStart ..< cursor])
+                    if cursor < value.endIndex {
+                        cursor = value.index(after: cursor)
+                    }
                 } else {
                     let valueStart = cursor
                     while cursor < value.endIndex, !value[cursor].isWhitespace { cursor = value.index(after: cursor) }
-                    attributeValue = String(value[valueStart..<cursor])
+                    attributeValue = String(value[valueStart ..< cursor])
                 }
             }
 
-            if !key.isEmpty { attributes[key] = attributeValue }
+            if !key.isEmpty {
+                attributes[key] = attributeValue
+            }
         }
 
         return (String(name).lowercased(), attributes, isSelfClosing)

--- a/SwiftCraftLauncher/ResourceFeature/ViewModels/Modrinth/ModrinthSearchViewModel.swift
+++ b/SwiftCraftLauncher/ResourceFeature/ViewModels/Modrinth/ModrinthSearchViewModel.swift
@@ -98,10 +98,17 @@ final class ModrinthSearchViewModel {
                 try Task.checkCancellation()
 
                 if !Task.isCancelled {
+                    #if DEBUG
+                    let hits = projectType == ResourceType.mod.rawValue && query.isEmpty
+                        ? [HTMLTestMod.project] + result.hits
+                        : result.hits
+                    #else
+                    let hits = result.hits
+                    #endif
                     if append {
-                        results.append(contentsOf: result.hits)
+                        results.append(contentsOf: hits)
                     } else {
-                        results = result.hits
+                        results = hits
                     }
                     totalHits = result.totalHits
                 }

--- a/SwiftCraftLauncher/ResourceFeature/ViewModels/Modrinth/ModrinthSearchViewModel.swift
+++ b/SwiftCraftLauncher/ResourceFeature/ViewModels/Modrinth/ModrinthSearchViewModel.swift
@@ -99,11 +99,11 @@ final class ModrinthSearchViewModel {
 
                 if !Task.isCancelled {
                     #if DEBUG
-                    let hits = projectType == ResourceType.mod.rawValue && query.isEmpty
-                        ? [HTMLTestMod.project] + result.hits
-                        : result.hits
+                        let hits = projectType == ResourceType.mod.rawValue && query.isEmpty
+                            ? [HTMLTestMod.project] + result.hits
+                            : result.hits
                     #else
-                    let hits = result.hits
+                        let hits = result.hits
                     #endif
                     if append {
                         results.append(contentsOf: hits)

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectContentView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectContentView.swift
@@ -77,12 +77,12 @@ struct ModrinthProjectContentView: View {
             )
         }
         #if DEBUG
-        if projectId == HTMLTestMod.projectId {
-            await MainActor.run {
-                projectDetail = HTMLTestMod.detail
+            if projectId == HTMLTestMod.projectId {
+                await MainActor.run {
+                    projectDetail = HTMLTestMod.detail
+                }
+                return
             }
-            return
-        }
         #endif
         let result = await ModrinthService.fetchProjectDetails(id: projectId, type: resourceType == ProjectType.minecraftJavaServer ? resourceType : "")
         await MainActor.run {

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectContentView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectContentView.swift
@@ -76,6 +76,14 @@ struct ModrinthProjectContentView: View {
                 message: "projectId is empty",
             )
         }
+        #if DEBUG
+        if projectId == HTMLTestMod.projectId {
+            await MainActor.run {
+                projectDetail = HTMLTestMod.detail
+            }
+            return
+        }
+        #endif
         let result = await ModrinthService.fetchProjectDetails(id: projectId, type: resourceType == ProjectType.minecraftJavaServer ? resourceType : "")
         await MainActor.run {
             projectDetail = result

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectDetailView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectDetailView.swift
@@ -163,31 +163,40 @@ private struct MarkdownContentSegment: Identifiable {
 }
 
 private enum MarkdownImageExtractor {
+    private struct ImageMatch {
+        let result: NSTextCheckingResult
+        let isLinked: Bool
+    }
+
+    // Only block-level images are extracted so inline images keep their original Markdown paragraph.
+    private static let linkedImagePattern = #"(?m)^[ \t]*\[!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)[ \t]*(?:\n|$)"#
+    private static let imagePattern = #"(?m)^[ \t]*!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)[ \t]*(?:\n|$)"#
+
     static func extract(from markdown: String) -> [MarkdownContentSegment] {
-        let pattern = #"(?m)^[ \t]*(?:\[!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)|!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\))[ \t]*(?:\n|$)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        guard let linkedRegex = try? NSRegularExpression(pattern: linkedImagePattern),
+              let imageRegex = try? NSRegularExpression(pattern: imagePattern) else {
             return [MarkdownContentSegment(content: .markdown(markdown))]
         }
 
         let range = NSRange(markdown.startIndex..., in: markdown)
-        let matches = regex.matches(in: markdown, range: range)
+        let matches = (
+            linkedRegex.matches(in: markdown, range: range).map { ImageMatch(result: $0, isLinked: true) }
+                + imageRegex.matches(in: markdown, range: range).map { ImageMatch(result: $0, isLinked: false) },
+        ).sorted { $0.result.range.location < $1.result.range.location }
         var segments: [MarkdownContentSegment] = []
         var cursor = markdown.startIndex
 
         for match in matches {
-            let sourceMatchRange = match.range(at: 2).location == NSNotFound
-                ? match.range(at: 5)
-                : match.range(at: 2)
-            guard let fullRange = Range(match.range, in: markdown),
-                  let sourceRange = Range(sourceMatchRange, in: markdown) else {
+            guard let fullRange = Range(match.result.range, in: markdown),
+                  let sourceRange = Range(match.result.range(at: 2), in: markdown) else {
                 continue
             }
-            let prefix = markdown[cursor..<fullRange.lowerBound]
+            let prefix = markdown[cursor ..< fullRange.lowerBound]
             if !prefix.isEmpty {
                 segments.append(MarkdownContentSegment(content: .markdown(String(prefix))))
             }
             let content: MarkdownContentSegment.Content
-            if let destinationRange = Range(match.range(at: 3), in: markdown) {
+            if match.isLinked, let destinationRange = Range(match.result.range(at: 3), in: markdown) {
                 content = .linkedImage(
                     source: String(markdown[sourceRange]),
                     destination: String(markdown[destinationRange]),

--- a/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectDetailView.swift
+++ b/SwiftCraftLauncher/ResourceFeature/Views/Modrinth/ModrinthProjectDetailView.swift
@@ -114,7 +114,7 @@ struct ModrinthProjectDetailView: View {
     }
 
     private func descriptionView(_ project: ModrinthProjectDetail) -> some View {
-        MixedMarkdownView(project.body)
+        RichContentView(content: project.body)
     }
 
     private var loadingView: some View {
@@ -123,6 +123,123 @@ struct ModrinthProjectDetailView: View {
                 .controlSize(.small)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct RichContentView: View {
+    let content: String
+
+    var body: some View {
+        let segments = MarkdownImageExtractor.extract(
+            from: HTMLToMarkdownConverter.convertIfNeeded(content),
+        )
+
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(segments) { segment in
+                switch segment.content {
+                case let .markdown(markdown):
+                    if !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        MixedMarkdownView(markdown)
+                    }
+                case let .image(source):
+                    BoundedMarkdownImageView(source: source)
+                case let .linkedImage(source, destination):
+                    BoundedMarkdownImageView(source: source, destination: destination)
+                }
+            }
+        }
+    }
+}
+
+private struct MarkdownContentSegment: Identifiable {
+    enum Content {
+        case markdown(String)
+        case image(String)
+        case linkedImage(source: String, destination: String)
+    }
+
+    let id = UUID()
+    let content: Content
+}
+
+private enum MarkdownImageExtractor {
+    static func extract(from markdown: String) -> [MarkdownContentSegment] {
+        let pattern = #"(?m)^[ \t]*(?:\[!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)|!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\))[ \t]*(?:\n|$)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [MarkdownContentSegment(content: .markdown(markdown))]
+        }
+
+        let range = NSRange(markdown.startIndex..., in: markdown)
+        let matches = regex.matches(in: markdown, range: range)
+        var segments: [MarkdownContentSegment] = []
+        var cursor = markdown.startIndex
+
+        for match in matches {
+            let sourceMatchRange = match.range(at: 2).location == NSNotFound
+                ? match.range(at: 5)
+                : match.range(at: 2)
+            guard let fullRange = Range(match.range, in: markdown),
+                  let sourceRange = Range(sourceMatchRange, in: markdown) else {
+                continue
+            }
+            let prefix = markdown[cursor..<fullRange.lowerBound]
+            if !prefix.isEmpty {
+                segments.append(MarkdownContentSegment(content: .markdown(String(prefix))))
+            }
+            let content: MarkdownContentSegment.Content
+            if let destinationRange = Range(match.range(at: 3), in: markdown) {
+                content = .linkedImage(
+                    source: String(markdown[sourceRange]),
+                    destination: String(markdown[destinationRange]),
+                )
+            } else {
+                content = .image(String(markdown[sourceRange]))
+            }
+            segments.append(MarkdownContentSegment(content: content))
+            cursor = fullRange.upperBound
+        }
+
+        let suffix = markdown[cursor...]
+        if !suffix.isEmpty {
+            segments.append(MarkdownContentSegment(content: .markdown(String(suffix))))
+        }
+        return segments.isEmpty ? [MarkdownContentSegment(content: .markdown(markdown))] : segments
+    }
+}
+
+private struct BoundedMarkdownImageView: View {
+    let source: String
+    let destination: String?
+
+    init(source: String, destination: String? = nil) {
+        self.source = source
+        self.destination = destination
+    }
+
+    var body: some View {
+        if let url = URL(string: source) {
+            let image = AsyncImage(url: url) { phase in
+                switch phase {
+                case let .success(image):
+                    image
+                        .interpolation(.high)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                case .failure:
+                    EmptyView()
+                default:
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let destination, let destinationURL = URL(string: destination) {
+                Link(destination: destinationURL) {
+                    image
+                }
+            } else {
+                image
+            }
+        }
     }
 }
 

--- a/SwiftCraftLauncherTests/Fixtures/modrinth/html_test_mod.html
+++ b/SwiftCraftLauncherTests/Fixtures/modrinth/html_test_mod.html
@@ -1,0 +1,29 @@
+<h1>HTML Test Mod</h1>
+<p>This is <strong>bold</strong>, <b>also bold</b>, <em>italic</em>, <i>also italic</i>, <s>struck</s>, and <del>deleted</del>.</p>
+<p>Read the <a href="https://example.com/project">project page</a> or press <button data-url="https://example.com/download">Download</button>.</p>
+<p>Inline image: <img src="https://example.com/icon.png" alt="Test icon" title="Icon" /></p>
+<div>Block one<br />Block two</div>
+<hr />
+<blockquote>A quoted line with <code>inlineCode()</code>.</blockquote>
+<pre><code>public func testMod() {
+    print("hello")
+}</code></pre>
+<ul>
+  <li>Fabric</li>
+  <li>Quilt</li>
+</ul>
+<ol>
+  <li>Install the mod</li>
+  <li>Launch Minecraft</li>
+</ol>
+<table>
+  <thead><tr><th>Loader</th><th>Version</th></tr></thead>
+  <tbody><tr><td>Fabric</td><td>1.21</td></tr><tr><td>Quilt</td><td>1.20.1</td></tr></tbody>
+</table>
+<figure><img src="https://example.com/banner.png" alt="Banner" /><figcaption>Test banner</figcaption></figure>
+<video src="https://example.com/demo.mp4" title="Demo video"></video>
+<audio><source src="https://example.com/demo.mp3" /></audio>
+<svg aria-label="Test icon"><path d="M0 0" /></svg>
+<details><summary>Advanced details</summary><p>Extra information.</p></details>
+<script>alert('must not execute')</script>
+<style>body { color: red; }</style>

--- a/SwiftCraftLauncherTests/ResourceFeature/Utilities/HTMLToMarkdownConverterTests.swift
+++ b/SwiftCraftLauncherTests/ResourceFeature/Utilities/HTMLToMarkdownConverterTests.swift
@@ -1,0 +1,72 @@
+//
+//  HTMLToMarkdownConverterTests.swift
+//  SwiftCraftLauncherTests
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+@testable import SwiftCraftLauncher
+import XCTest
+
+final class HTMLToMarkdownConverterTests: XCTestCase {
+    func testTestModFixtureCoversSupportedHTML() throws {
+        let fixtureURL = TestSupport.fixtureURL(
+            subdirectory: "Fixtures/modrinth",
+            name: "html_test_mod",
+            extension: "html",
+        )
+        let html = try String(contentsOf: fixtureURL, encoding: .utf8)
+
+        let markdown = HTMLToMarkdownConverter.convert(html)
+
+        XCTAssertTrue(markdown.contains("# HTML Test Mod"))
+        XCTAssertTrue(markdown.contains("**bold**"))
+        XCTAssertTrue(markdown.contains("*italic*"))
+        XCTAssertTrue(markdown.contains("~~struck~~"))
+        XCTAssertTrue(markdown.contains("[project page](https://example.com/project)"))
+        XCTAssertTrue(markdown.contains("[Download](https://example.com/download)"))
+        XCTAssertTrue(markdown.contains("![Test icon](https://example.com/icon.png)"))
+        XCTAssertTrue(markdown.contains("Block one\nBlock two"))
+        XCTAssertTrue(markdown.contains("---"))
+        XCTAssertTrue(markdown.contains("> A quoted line"))
+        XCTAssertTrue(markdown.contains("`inlineCode()`"))
+        XCTAssertTrue(markdown.contains("```\npublic func testMod()"))
+        XCTAssertTrue(markdown.contains("- Fabric"))
+        XCTAssertTrue(markdown.contains("1. Install the mod"))
+        XCTAssertTrue(markdown.contains("| Loader | Version |"))
+        XCTAssertTrue(markdown.contains("| Fabric | 1.21 |"))
+        XCTAssertTrue(markdown.contains("[Demo video](https://example.com/demo.mp4)"))
+        XCTAssertTrue(markdown.contains("[🔊 Audio](https://example.com/demo.mp3)"))
+        XCTAssertTrue(markdown.contains("[Test icon]"))
+        XCTAssertTrue(markdown.contains("Advanced details"))
+        XCTAssertFalse(markdown.contains("alert('must not execute')"))
+        XCTAssertFalse(markdown.contains("color: red"))
+    }
+
+    func testButtonOnclickIsConvertedToSafeLink() {
+        let html = #"<button onclick="window.open('https://example.com/install')">Install</button>"#
+
+        XCTAssertEqual(
+            HTMLToMarkdownConverter.convert(html),
+            "[Install](https://example.com/install)",
+        )
+    }
+
+    func testUnsafeLinksAreNotEmittedAsMarkdownLinks() {
+        let html = #"<a href="javascript:alert('x')">Unsafe</a><img src="file:///tmp/secret" alt="Secret">"#
+
+        XCTAssertEqual(HTMLToMarkdownConverter.convert(html), "UnsafeSecret")
+    }
+
+    func testEntitiesAndUnknownTagsKeepReadableText() {
+        let html = "<custom>Tom &amp; Jerry</custom><span> still readable</span>"
+
+        XCTAssertEqual(HTMLToMarkdownConverter.convert(html), "Tom & Jerry still readable")
+    }
+
+    func testNestedListsKeepTheirStructure() {
+        let html = "<ul><li>Parent<ul><li>Child</li></ul></li></ul>"
+
+        XCTAssertEqual(HTMLToMarkdownConverter.convert(html), "- Parent\n  - Child")
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Improve Modrinth project detail rendering by safely converting HTML descriptions to Markdown and displaying images within layout bounds.

New Features:
- Convert supported Modrinth project-description HTML into readable Markdown, including formatting, links, media, lists, tables, and other common content.
- Render block-level Markdown images with bounded asynchronous loading while preserving linked-image navigation.

Bug Fixes:
- Prevent image content from exceeding the available layout width.
- Guard newer button-sizing APIs behind compiler availability checks for compatibility with older toolchains.

Enhancements:
- Add a DEBUG-only HTML fixture project for manually exercising the resource description renderer.

Tests:
- Add converter tests covering supported HTML elements, entity decoding, safe links, unsupported content, and nested lists.