### PR TITLE
fix(auth):引导创建 Minecraft 游戏档案

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
+++ b/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
@@ -118,6 +118,10 @@ struct MinecraftEntitlementsResponse: Codable {
     let keyId: String
 }
 
+struct MinecraftLicenseResponse: Codable {
+    let items: [EntitlementItem]
+}
+
 struct EntitlementItem: Codable {
     let name: String
     let signature: String
@@ -133,6 +137,29 @@ enum MinecraftEntitlement: String, CaseIterable {
             return "Minecraft Product License"
         case .gameMinecraft:
             return "Minecraft Game License"
+        }
+    }
+}
+
+enum MinecraftAuthenticationIssue: Equatable {
+    case profileMissing
+    case notPurchased
+
+    var actionTitleKey: String {
+        switch self {
+        case .profileMissing:
+            "minecraft.auth.create_profile"
+        case .notPurchased:
+            "addplayer.purchase.minecraft"
+        }
+    }
+
+    var actionURL: URL {
+        switch self {
+        case .profileMissing:
+            URL(string: "https://www.minecraft.net/msaprofile/mygames/editprofile") ?? URL(fileURLWithPath: "/")
+        case .notPurchased:
+            URLConfig.Store.minecraftPurchase
         }
     }
 }

--- a/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
+++ b/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
@@ -145,15 +145,6 @@ enum MinecraftAuthenticationIssue: Equatable {
     case profileMissing
     case notPurchased
 
-    var actionTitleKey: String {
-        switch self {
-        case .profileMissing:
-            "minecraft.auth.create_profile"
-        case .notPurchased:
-            "addplayer.purchase.minecraft"
-        }
-    }
-
     var actionURL: URL {
         switch self {
         case .profileMissing:

--- a/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
+++ b/SwiftCraftLauncher/CommonFeature/Models/Auth/MinecraftAuth.swift
@@ -148,7 +148,7 @@ enum MinecraftAuthenticationIssue: Equatable {
     var actionURL: URL {
         switch self {
         case .profileMissing:
-            URL(string: "https://www.minecraft.net/msaprofile/mygames/editprofile") ?? URL(fileURLWithPath: "/")
+            URLConfig.Store.minecraftProfileCreation
         case .notPurchased:
             URLConfig.Store.minecraftPurchase
         }

--- a/SwiftCraftLauncher/CommonFeature/Services/MinecraftAuth/MinecraftAuthService+TokenChain.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/MinecraftAuth/MinecraftAuthService+TokenChain.swift
@@ -231,7 +231,26 @@ extension MinecraftAuthService {
     ) async throws -> MinecraftProfileResponse {
         let url = URLConfig.API.Authentication.minecraftProfile
         let headers = [APIClient.Header.authorization: APIClient.bearer(accessToken)]
-        let data = try await APIClient.get(url: url, headers: headers)
+        let data: Data
+        do {
+            data = try await APIClient.get(url: url, headers: headers)
+        } catch let error as GlobalError where error.statusCode == 404 {
+            let licenseData = try await APIClient.get(
+                url: URLConfig.API.Authentication.minecraftLicense,
+                headers: headers,
+            )
+            let license = try JSONDecoder().decode(MinecraftLicenseResponse.self, from: licenseData)
+            let hasMinecraftLicense = license.items.contains {
+                $0.name == MinecraftEntitlement.gameMinecraft.rawValue
+            }
+            throw GlobalError.authentication(
+                i18nKey: hasMinecraftLicense
+                    ? "error.authentication.minecraft_profile_missing"
+                    : "error.authentication.minecraft_not_purchased",
+                level: .popup,
+                message: "Minecraft profile lookup returned 404; licensePresent=\(hasMinecraftLicense)",
+            )
+        }
 
         do {
             let profile = try JSONDecoder().decode(MinecraftProfileResponse.self, from: data)

--- a/SwiftCraftLauncher/CommonFeature/Services/MinecraftAuth/MinecraftAuthService.swift
+++ b/SwiftCraftLauncher/CommonFeature/Services/MinecraftAuth/MinecraftAuthService.swift
@@ -15,6 +15,7 @@ import SwiftUI
 final class MinecraftAuthService: @unchecked Sendable {
     var authState: AuthenticationState = .idle
     var isLoading: Bool = false
+    var authenticationIssue: MinecraftAuthenticationIssue?
 
     let clientId = AppConstants.minecraftClientId
     let scope = AppConstants.minecraftScope
@@ -29,6 +30,7 @@ final class MinecraftAuthService: @unchecked Sendable {
         webAuthenticator.cancel()
 
         isLoading = true
+        authenticationIssue = nil
         authState = .waitingForBrowser
 
         guard let authURL = buildAuthorizationURL() else {
@@ -140,6 +142,11 @@ final class MinecraftAuthService: @unchecked Sendable {
         } catch {
             let globalError = GlobalError.from(error)
             AppLog.common.error("Minecraft authentication failed: \(globalError.localizedDescription)")
+            authenticationIssue = switch globalError.i18nKey {
+            case "error.authentication.minecraft_profile_missing": .profileMissing
+            case "error.authentication.minecraft_not_purchased": .notPurchased
+            default: nil
+            }
             isLoading = false
             authState = .error(globalError.localizedDescription)
         }
@@ -148,6 +155,7 @@ final class MinecraftAuthService: @unchecked Sendable {
     @MainActor
     func logout() {
         authState = .idle
+        authenticationIssue = nil
         webAuthenticator.cancel()
         isLoading = false
     }

--- a/SwiftCraftLauncher/CommonFeature/Utilities/Network/URLConfig.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/Network/URLConfig.swift
@@ -31,6 +31,7 @@ enum URLConfig {
             static let minecraftLogin = URLConfig.url("https://api.minecraftservices.com/authentication/login_with_xbox")
             static let minecraftProfile = URLConfig.url("https://api.minecraftservices.com/minecraft/profile")
             static let minecraftEntitlements = URLConfig.url("https://api.minecraftservices.com/entitlements/mcstore")
+            static let minecraftLicense = URLConfig.url("https://api.minecraftservices.com/entitlements/license")
             static let minecraftRelyingParty = "rp://api.minecraftservices.com/"
             static let minecraftProfileSkins = URLConfig.url("https://api.minecraftservices.com/minecraft/profile/skins")
             static let minecraftProfileActiveSkin = URLConfig.url("https://api.minecraftservices.com/minecraft/profile/skins/active")

--- a/SwiftCraftLauncher/CommonFeature/Utilities/Network/URLConfig.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/Network/URLConfig.swift
@@ -402,5 +402,8 @@ enum URLConfig {
     enum Store {
         /// The Minecraft purchase page URL on the Xbox store.
         static let minecraftPurchase = URLConfig.url("https://www.xbox.com/zh-CN/games/store/productId/9NXP44L49SHJ")
+
+        /// The Minecraft page for creating a Java Edition game profile.
+        static let minecraftProfileCreation = URLConfig.url("https://www.minecraft.net/msaprofile/mygames/editprofile")
     }
 }

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/AddPlayerSheetView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/AddPlayerSheetView.swift
@@ -120,12 +120,22 @@ struct AddPlayerSheetView: View {
                             .keyboardShortcut(.defaultAction)
 
                         case .error:
-                            Button("addplayer.auth.retry".localized()) {
-                                Task {
-                                    await viewModel.startPremiumAuthentication(authService: container.system.minecraftAuthService)
+                            if let issue = container.system.minecraftAuthService.authenticationIssue,
+                               issue == .profileMissing {
+                                Button(issue.actionTitleKey.localized()) {
+                                    openURL(issue.actionURL)
                                 }
+                                .keyboardShortcut(.defaultAction)
+                            } else {
+                                Button("addplayer.auth.retry".localized()) {
+                                    Task {
+                                        await viewModel.startPremiumAuthentication(
+                                            authService: container.system.minecraftAuthService,
+                                        )
+                                    }
+                                }
+                                .keyboardShortcut(.defaultAction)
                             }
-                            .keyboardShortcut(.defaultAction)
 
                         default:
                             ProgressView().controlSize(.small)

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/AddPlayerSheetView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/AddPlayerSheetView.swift
@@ -122,7 +122,7 @@ struct AddPlayerSheetView: View {
                         case .error:
                             if let issue = container.system.minecraftAuthService.authenticationIssue,
                                issue == .profileMissing {
-                                Button(issue.actionTitleKey.localized()) {
+                                Button("minecraft.auth.create_profile".localized()) {
                                     openURL(issue.actionURL)
                                 }
                                 .keyboardShortcut(.defaultAction)

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
@@ -145,9 +145,22 @@ struct MinecraftAuthView: View {
         let statusColor: Color = isProfileMissing ? .yellow : .red
 
         return VStack(spacing: 16) {
-            Image(systemName: isProfileMissing ? "person.crop.circle.badge.exclamationmark" : "exclamationmark.triangle")
-                .font(.system(size: 60))
-                .foregroundColor(statusColor)
+            if isProfileMissing {
+                ZStack(alignment: .bottomLeading) {
+                    Image(systemName: "person.crop.circle.fill")
+                        .font(.system(size: 60))
+                        .foregroundStyle(.gray)
+
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .font(.system(size: 30))
+                        .foregroundStyle(.yellow, .white)
+                }
+                .frame(width: 60, height: 60)
+            } else {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 60))
+                    .foregroundColor(statusColor)
+            }
 
             Text("minecraft.auth.failed".localized())
                 .font(.headline)

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
@@ -146,16 +146,11 @@ struct MinecraftAuthView: View {
 
         return VStack(spacing: 16) {
             if isProfileMissing {
-                ZStack(alignment: .bottomLeading) {
-                    Image(systemName: "person.crop.circle.fill")
-                        .font(.system(size: 60))
-                        .foregroundStyle(.gray)
-
-                    Image(systemName: "exclamationmark.circle.fill")
-                        .font(.system(size: 30))
-                        .foregroundStyle(.yellow, .white)
-                }
-                .frame(width: 60, height: 60)
+                Image(systemName: "person.crop.circle.badge.exclamationmark")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                    .symbolRenderingMode(.multicolor)
+                    .symbolVariant(.none)
             } else {
                 Image(systemName: "exclamationmark.triangle")
                     .font(.system(size: 60))
@@ -179,7 +174,7 @@ struct MinecraftAuthView: View {
                     : "minecraft.auth.retry_message".localized(),
             )
             .font(.caption)
-            .foregroundColor(.secondary)
+            .foregroundColor(isProfileMissing ? .red : .secondary)
             .multilineTextAlignment(.center)
         }
     }

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
@@ -155,10 +155,16 @@ struct MinecraftAuthView: View {
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
 
-            Text("minecraft.auth.retry_message".localized())
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
+            let issue = container.system.minecraftAuthService.authenticationIssue
+
+            Text(
+                issue == .profileMissing
+                    ? "minecraft.auth.create_profile_message".localized()
+                    : "minecraft.auth.retry_message".localized(),
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.center)
         }
     }
 }

--- a/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/AddPlayer/MinecraftAuthView.swift
@@ -141,14 +141,17 @@ struct MinecraftAuthView: View {
     }
 
     private func errorView(message: String) -> some View {
-        VStack(spacing: 16) {
-            Image(systemName: "exclamationmark.triangle")
+        let isProfileMissing = container.system.minecraftAuthService.authenticationIssue == .profileMissing
+        let statusColor: Color = isProfileMissing ? .yellow : .red
+
+        return VStack(spacing: 16) {
+            Image(systemName: isProfileMissing ? "person.crop.circle.badge.exclamationmark" : "exclamationmark.triangle")
                 .font(.system(size: 60))
-                .foregroundColor(.red)
+                .foregroundColor(statusColor)
 
             Text("minecraft.auth.failed".localized())
                 .font(.headline)
-                .foregroundColor(.red)
+                .foregroundColor(statusColor)
 
             Text(message)
                 .font(.subheadline)

--- a/SwiftCraftLauncher/Resources/Localizable.xcstrings
+++ b/SwiftCraftLauncher/Resources/Localizable.xcstrings
@@ -10052,13 +10052,127 @@
       }
     },
     "error.authentication.minecraft_profile_missing" : {
-      "shouldTranslate" : false,
+      "shouldTranslate" : true,
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم شراء إصدار Java من Minecraft، ولكن لم يتم إنشاء ملف تعريف للعبة بعد."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition er købt, men der er endnu ikke oprettet en spilprofil."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition wurde gekauft, aber es wurde noch kein Spielprofil erstellt."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minecraft Java Edition is owned, but no game profile has been created."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition es de tu propiedad, pero aún no se ha creado un perfil de juego."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition on ostettu, mutta peliprofiilia ei ole vielä luotu."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition est acheté, mais aucun profil de jeu n’a encore été créé."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition खरीदा गया है, लेकिन अभी तक कोई गेम प्रोफ़ाइल नहीं बनाई गई है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition è stata acquistata, ma non è ancora stato creato alcun profilo di gioco."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition は購入済みですが、ゲームプロフィールがまだ作成されていません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition을 보유하고 있지만 게임 프로필이 아직 생성되지 않았습니다."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition er kjøpt, men ingen spillprofil er opprettet ennå."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition is gekocht, maar er is nog geen spelprofiel aangemaakt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition jest kupiona, ale nie utworzono jeszcze profilu gry."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition foi comprada, mas ainda não foi criado um perfil de jogo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition приобретена, но игровой профиль ещё не создан."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition är köpt, men ingen spelprofil har skapats än."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "มี Minecraft Java Edition แล้ว แต่ยังไม่ได้สร้างโปรไฟล์เกม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition satın alındı, ancak henüz bir oyun profili oluşturulmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn đã sở hữu Minecraft Java Edition nhưng chưa tạo hồ sơ trò chơi."
           }
         },
         "zh-Hans" : {
@@ -10066,17 +10180,137 @@
             "state" : "translated",
             "value" : "已拥有 Minecraft Java 版，但尚未创建游戏档案"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已擁有 Minecraft Java 版，但尚未建立遊戲檔案"
+          }
         }
       }
     },
     "minecraft.auth.create_profile" : {
-      "shouldTranslate" : false,
+      "shouldTranslate" : true,
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء ملف تعريف"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opret profil"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil erstellen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Create profile"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear perfil"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luo profiili"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer un profil"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "प्रोफ़ाइल बनाएँ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea profilo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロフィールを作成"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프로필 만들기"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opprett profil"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profiel aanmaken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utwórz profil"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criar perfil"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать профиль"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skapa profil"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "สร้างโปรไฟล์"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil oluştur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo hồ sơ"
           }
         },
         "zh-Hans" : {
@@ -10084,23 +10318,149 @@
             "state" : "translated",
             "value" : "前往创建"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往建立"
+          }
         }
       }
     },
     "minecraft.auth.create_profile_message" : {
-      "shouldTranslate" : false,
+      "shouldTranslate" : true,
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يرجى النقر على زر «إنشاء ملف تعريف» لإنشاء ملف تعريف لعبة Minecraft."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klik på knappen \"Opret profil\" for at oprette din Minecraft-spilprofil."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klicke auf „Profil erstellen“, um dein Minecraft-Spielprofil zu erstellen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Please click \"Create profile\" to create your Minecraft game profile."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz clic en «Crear perfil» para crear tu perfil de juego de Minecraft."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luo Minecraft-peliprofiilisi napsauttamalla Luo profiili -painiketta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez sur le bouton « Créer un profil » pour créer votre profil de jeu Minecraft."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अपनी Minecraft गेम प्रोफ़ाइल बनाने के लिए “प्रोफ़ाइल बनाएँ” बटन पर क्लिक करें।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fai clic sul pulsante “Crea profilo” per creare il tuo profilo di gioco Minecraft."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「プロフィールを作成」ボタンをクリックして、Minecraft のゲームプロフィールを作成してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft 게임 프로필을 만들려면 “프로필 만들기” 버튼을 클릭하세요."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klikk på knappen «Opprett profil» for å opprette Minecraft-spillprofilen din."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klik op de knop ‘Profiel aanmaken’ om je Minecraft-spelprofiel aan te maken."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kliknij przycisk „Utwórz profil”, aby utworzyć swój profil gry Minecraft."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clique no botão “Criar perfil” para criar o seu perfil de jogo do Minecraft."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите кнопку «Создать профиль», чтобы создать игровой профиль Minecraft."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klicka på knappen ”Skapa profil” för att skapa din Minecraft-spelprofil."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "คลิกปุ่ม “สร้างโปรไฟล์” เพื่อสร้างโปรไฟล์เกม Minecraft ของคุณ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft oyun profilinizi oluşturmak için “Profil oluştur” düğmesine tıklayın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhấp vào nút “Tạo hồ sơ” để tạo hồ sơ trò chơi Minecraft của bạn."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请点击“前往创建”按钮来创建游戏档案"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請點擊「前往建立」按鈕以建立 Minecraft 遊戲檔案。"
           }
         }
       }

--- a/SwiftCraftLauncher/Resources/Localizable.xcstrings
+++ b/SwiftCraftLauncher/Resources/Localizable.xcstrings
@@ -10051,6 +10051,60 @@
         }
       }
     },
+    "error.authentication.minecraft_profile_missing" : {
+      "shouldTranslate" : false,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minecraft Java Edition is owned, but no game profile has been created."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拥有 Minecraft Java 版，但尚未创建游戏档案"
+          }
+        }
+      }
+    },
+    "minecraft.auth.create_profile" : {
+      "shouldTranslate" : false,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create profile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往创建"
+          }
+        }
+      }
+    },
+    "minecraft.auth.create_profile_message" : {
+      "shouldTranslate" : false,
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please click \"Create profile\" to create your Minecraft game profile."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请点击“前往创建”按钮来创建游戏档案"
+          }
+        }
+      }
+    },
     "error.authentication.missing_token" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SwiftCraftLauncherTests/CommonFeature/Services/MinecraftAuthExtendedTests.swift
+++ b/SwiftCraftLauncherTests/CommonFeature/Services/MinecraftAuthExtendedTests.swift
@@ -149,6 +149,21 @@ final class MinecraftAuthExtendedTests: XCTestCase {
         XCTAssertNil(decoded.capes)
     }
 
+    func testMinecraftLicenseResponse_codable_detectsGameLicense() throws {
+        let json = Data("""
+        {
+            "items": [
+                {"name": "product_minecraft", "signature": "signature-1"},
+                {"name": "game_minecraft", "signature": "signature-2"}
+            ]
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(MinecraftLicenseResponse.self, from: json)
+
+        XCTAssertTrue(decoded.items.contains { $0.name == MinecraftEntitlement.gameMinecraft.rawValue })
+    }
+
     func testMinecraftProfileResponse_init_directValues() {
         let skins = [Skin(state: "ACTIVE", url: "url", variant: "classic")]
         let capes = [Cape(id: "c1", state: "ACTIVE", url: "cape-url", alias: nil)]


### PR DESCRIPTION
## Summary by Sourcery

Guide Minecraft authentication users toward profile creation or purchase when their account cannot access a game profile.

New Features:
- Detect whether a Microsoft account has purchased Minecraft when no Minecraft profile exists and distinguish the resulting authentication issue.
- Guide users to create a Minecraft game profile when their account owns the game but lacks a profile.

Enhancements:
- Provide targeted authentication errors and recovery actions for missing profiles and unpurchased Minecraft accounts.

Tests:
- Add coverage for decoding Minecraft license responses and detecting the game entitlement.