### PR TITLE
fix: 修复内存范围滑块数字位数变化导致设置页布局抖动

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Views/Components/MemoryRangeLabel.swift
+++ b/SwiftCraftLauncher/CommonFeature/Views/Components/MemoryRangeLabel.swift
@@ -1,0 +1,58 @@
+//
+//  MemoryRangeLabel.swift
+//  CommonFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import SwiftUI
+
+/// A memory-range readout (for example `512 MB-4096 MB`) whose layout width
+/// stays constant while the displayed values change.
+///
+/// `MiniRangeSlider` mirrors its selection into this neighbouring label.
+/// Because the digit count changes while dragging (`999` -> `1024`,
+/// `4096` -> `8192`), a plain `Text` grows and shrinks on every value
+/// change. Inside the trailing-aligned content block of a `LabeledContent`,
+/// that width change shifts the slider and the adjacent reset button
+/// horizontally on each tick, which the user perceives as page jitter.
+///
+/// This view reserves space for the widest value the bounds allow (a hidden
+/// sizer rendered with the same font) so the occupied width is constant
+/// regardless of the current selection. Monospaced digits additionally keep
+/// same-digit-count values from wiggling pixel-by-pixel.
+struct MemoryRangeLabel: View {
+    /// The currently selected range to display.
+    let range: ClosedRange<Double>
+    /// The slider bounds. `upperBound` drives the reserved layout width.
+    let bounds: ClosedRange<Double>
+
+    private var displayText: String {
+        "\(Int(range.lowerBound)) MB-\(Int(range.upperBound)) MB"
+    }
+
+    /// The widest string the bounds can produce, used only to reserve layout
+    /// width so it never changes while the user drags.
+    private var sizerText: String {
+        let maxMegabytes = Int(max(bounds.upperBound, range.lowerBound, range.upperBound))
+        return "\(maxMegabytes) MB-\(maxMegabytes) MB"
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            // Hidden sizer: renders the widest possible value so the ZStack
+            // keeps a constant intrinsic width throughout a drag.
+            Text(sizerText)
+                .font(.subheadline)
+                .hidden()
+            Text(displayText)
+                .font(.subheadline)
+                .monospacedDigit()
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityLabel(displayText)
+    }
+}

--- a/SwiftCraftLauncher/GameFeature/Views/Settings/GameAdvancedSettingsView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/Settings/GameAdvancedSettingsView.swift
@@ -85,17 +85,15 @@ struct GameAdvancedSettingsView: View {
 
             LabeledContent("settings.game.java.memory".localized()) {
                 HStack {
+                    let memoryBounds = Double(AppConstants.MemoryDefaults.xms) ... Double(container.ui.gameSettingsManager.maximumMemoryAllocation)
                     MiniRangeSlider(
                         range: $viewModel.memoryRange,
-                        bounds: Double(AppConstants.MemoryDefaults.xms) ... Double(container.ui.gameSettingsManager.maximumMemoryAllocation),
+                        bounds: memoryBounds,
                     )
                     .frame(width: 200)
                     .controlSize(.mini)
                     .onChange(of: viewModel.memoryRange) { _, _ in viewModel.didChangeMemoryRange() }
-                    Text("\(Int(viewModel.memoryRange.lowerBound)) MB-\(Int(viewModel.memoryRange.upperBound)) MB")
-                        .font(.subheadline)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    MemoryRangeLabel(range: viewModel.memoryRange, bounds: memoryBounds)
                     Button("common.reset".localized()) {
                         viewModel.resetGameXms()
                     }

--- a/SwiftCraftLauncher/GameFeature/Views/Settings/GameSettingsView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/Settings/GameSettingsView.swift
@@ -106,10 +106,10 @@ public struct GameSettingsView: View {
                 Group {
                     LabeledContent("settings.default_memory_allocation.label".localized()) {
                         HStack {
+                            let memoryBounds = Double(AppConstants.MemoryDefaults.xms) ... Double(gameSettingsManager.maximumMemoryAllocation)
                             MiniRangeSlider(
                                 range: $globalMemoryRange,
-                                bounds:
-                                Double(AppConstants.MemoryDefaults.xms) ... Double(gameSettingsManager.maximumMemoryAllocation),
+                                bounds: memoryBounds,
                             )
                             .frame(width: 200)
                             .controlSize(.mini)
@@ -123,13 +123,7 @@ public struct GameSettingsView: View {
                                         gameSettingsManager.globalXms,
                                     ) ... Double(gameSettingsManager.globalXmx)
                             }
-                            Text(
-                                "\(Int(globalMemoryRange.lowerBound)) MB-\(Int(globalMemoryRange.upperBound)) MB",
-                            )
-                            .font(.subheadline)
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                            MemoryRangeLabel(range: globalMemoryRange, bounds: memoryBounds)
                             Button("common.reset".localized()) {
                                 gameSettingsManager.globalXms = AppConstants.MemoryDefaults.xms
                                 gameSettingsManager.globalXmx = AppConstants.MemoryDefaults.xmx


### PR DESCRIPTION
## 为什么需要这个改动

设置页（全局设置与高级设置）的内存分配行中，MiniRangeSlider 右侧的数字标签
`Text("\(x) MB-\(y) MB")` 宽度会随数字位数变化（如 999→1024、4096→8192）。
该行位于 Form 的 LabeledContent 内容区（尾部对齐），数字宽度一变，整块内容
从右向左伸缩，滑块左边缘随之横向位移——拖动滑块时滑块在光标下跳动，
页面产生明显抖动。

## 改动内容

- 新增 `MemoryRangeLabel`（`CommonFeature/Views/Components/MemoryRangeLabel.swift`）：
  用隐藏的"最大可能值"占位文本（同字体）经 `ZStack + fixedSize` 预留恒定宽度，
  并配合 `.monospacedDigit()`，使数字标签宽度不随数值变化 → HStack 总宽恒定 → 滑块位置稳定。
- `GameSettingsView.swift` / `GameAdvancedSettingsView.swift`：内存行改用
  `MemoryRangeLabel`，并把滑块 bounds 提取为局部常量复用。

## 验证

- xcodebuild（Debug, macOS）：BUILD SUCCEEDED
- SwiftLint --strict：3 个改动文件 0 violations
- SwiftFormat 0.62.1 --lint：0/3 需要格式化
- .github/scripts/check_code_rules.py：全部 549 个文件通过

## Summary by Sourcery

Stabilize memory allocation controls by keeping the range label width constant while values change.

Bug Fixes:
- Prevent memory range slider rows in the global and advanced settings views from shifting as displayed memory values change digit count.

Enhancements:
- Centralize memory range label rendering with a fixed-width, monospaced-digit component and reuse local slider bounds in both settings views.