### PR TITLE
feat: add MMC (MultiMC/PrismLauncher) modpack import support

### DIFF
--- a/SwiftCraftLauncher/ModPackFeature/Models/ModrinthIndexModels.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Models/ModrinthIndexModels.swift
@@ -135,6 +135,7 @@ struct ModrinthIndexFile: Codable {
 enum FileSource: String, Codable {
     case modrinth
     case curseforge
+    case mmc
 }
 
 /// Environment compatibility for a mod file.

--- a/SwiftCraftLauncher/ModPackFeature/Services/FailedResourceResolver.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Services/FailedResourceResolver.swift
@@ -70,6 +70,9 @@ enum FailedResourceResolver {
         case .modrinth:
             guard let sha1 = file.hashes.sha1 else { return nil }
             projectDetail = try? await ModrinthService.fetchModrinthDetailThrowing(by: sha1)
+        case .mmc:
+            // MMC packs don't have a centralized project API for resolution.
+            return nil
         }
 
         guard let projectDetail else { return nil }

--- a/SwiftCraftLauncher/ModPackFeature/Services/Index/MMCIndexAdapter.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Services/Index/MMCIndexAdapter.swift
@@ -1,0 +1,184 @@
+//
+//  MMCIndexAdapter.swift
+//  ModPackFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+
+/// Parses MultiMC / PrismLauncher mod pack archives into a normalized index representation.
+///
+/// MMC packs are identified by the presence of `mmc-pack.json` (component profile)
+/// and optionally `instance.cfg` (instance metadata). The actual game files live in
+/// the `minecraft/` subdirectory, which is treated as an overrides folder during
+/// installation.
+struct MMCIndexAdapter: ModPackIndexAdapter {
+    let id: String = "mmc"
+
+    /// Parsed result from mmc-pack.json.
+    private struct MMCPackInfo {
+        let minecraftVersion: String
+        let loaderInfo: (type: String, version: String)
+        let name: String?
+        let version: String?
+    }
+
+    func canParse(extractedPath: URL) async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            let packJsonPath = extractedPath.appendingPathComponent("mmc-pack.json").path
+            return FileManager.default.fileExists(atPath: packJsonPath)
+        }.value
+    }
+
+    func parseToModrinthIndexInfo(extractedPath: URL) async -> ModrinthIndexInfo? {
+        guard let packJson = await parsePackJson(extractedPath: extractedPath) else {
+            return nil
+        }
+
+        let gameVersion = packJson.minecraftVersion
+        let loaderInfo = packJson.loaderInfo
+        let instanceName = await parseInstanceCfgName(extractedPath: extractedPath)
+        let modPackName = instanceName ?? packJson.name ?? "MMC Modpack"
+
+        AppLog.modPack.info(
+            "MMC pack parsed: \(modPackName) — Minecraft \(gameVersion), loader: \(loaderInfo.type) \(loaderInfo.version)",
+        )
+
+        return ModrinthIndexInfo(
+            gameVersion: gameVersion,
+            loaderType: loaderInfo.type,
+            loaderVersion: loaderInfo.version,
+            modPackName: modPackName,
+            modPackVersion: packJson.version ?? "mmc",
+            summary: nil,
+            files: [],
+            dependencies: [],
+            source: .mmc,
+        )
+    }
+
+    private func parsePackJson(extractedPath: URL) async -> MMCPackInfo? {
+        let packJsonPath = extractedPath.appendingPathComponent("mmc-pack.json")
+
+        return await Task.detached(priority: .userInitiated) {
+            guard FileManager.default.fileExists(atPath: packJsonPath.path) else {
+                AppLog.modPack.error("mmc-pack.json not found at \(packJsonPath.path)")
+                return nil
+            }
+
+            guard let data = try? Data(contentsOf: packJsonPath), !data.isEmpty else {
+                AppLog.modPack.error("mmc-pack.json is empty or unreadable")
+                return nil
+            }
+
+            let decoder = JSONDecoder()
+            guard let pack = try? decoder.decode(MMCPackJson.self, from: data) else {
+                AppLog.modPack.error("Failed to decode mmc-pack.json: invalid JSON structure")
+                return nil
+            }
+
+            // Extract Minecraft version and loader info from components.
+            var minecraftVersion: String?
+            var loaderType: String?
+            var loaderVersion: String?
+
+            for component in pack.components {
+                let uid = component.uid.lowercased()
+                switch uid {
+                case "net.minecraft":
+                    minecraftVersion = component.version
+                case "net.fabricmc.fabric-loader":
+                    loaderType = GameLoader.fabric.displayName
+                    loaderVersion = component.version
+                case "org.quiltmc.quilt-loader":
+                    loaderType = GameLoader.quilt.rawValue
+                    loaderVersion = component.version
+                case "net.minecraftforge":
+                    loaderType = GameLoader.forge.displayName
+                    loaderVersion = component.version
+                case "net.neoforge":
+                    loaderType = GameLoader.neoforge.displayName
+                    loaderVersion = component.version
+                default:
+                    break
+                }
+            }
+
+            guard let mcVersion = minecraftVersion else {
+                AppLog.modPack.error("mmc-pack.json does not contain a net.minecraft component")
+                return nil
+            }
+
+            let resolvedLoaderType = loaderType ?? GameLoader.vanilla.displayName
+            let resolvedLoaderVersion = loaderVersion ?? "unknown"
+
+            return MMCPackInfo(
+                minecraftVersion: mcVersion,
+                loaderInfo: (resolvedLoaderType, resolvedLoaderVersion),
+                name: pack.name,
+                version: pack.versionId,
+            )
+        }.value
+    }
+
+    private func parseInstanceCfgName(extractedPath: URL) async -> String? {
+        await Task.detached(priority: .userInitiated) {
+            let cfgPath = extractedPath.appendingPathComponent("instance.cfg")
+            guard FileManager.default.fileExists(atPath: cfgPath.path),
+                  let data = try? Data(contentsOf: cfgPath),
+                  let content = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+
+            return Self.parseIniValue(content: content, key: "name")
+        }.value
+    }
+
+    /// Parses a simple INI file and returns the value for the given key from any section.
+    private static func parseIniValue(content: String, key: String) -> String? {
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Skip section headers and comments.
+            if trimmed.hasPrefix("[") || trimmed.hasPrefix("#") || trimmed.hasPrefix(";") {
+                continue
+            }
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 {
+                let k = parts[0].trimmingCharacters(in: .whitespaces)
+                let v = parts[1].trimmingCharacters(in: .whitespaces)
+                if k == key {
+                    return v.isEmpty ? nil : v
+                }
+            }
+        }
+        return nil
+    }
+}
+
+/// Top-level structure of `mmc-pack.json`.
+private struct MMCPackJson: Codable {
+    let formatVersion: Int?
+    let components: [MMCComponent]
+    let name: String?
+    let versionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case formatVersion
+        case components
+        case name
+        case versionId
+    }
+}
+
+/// A single component entry in `mmc-pack.json`.
+private struct MMCComponent: Codable {
+    let uid: String
+    let version: String?
+
+    enum CodingKeys: String, CodingKey {
+        case uid
+        case version
+    }
+}

--- a/SwiftCraftLauncher/ModPackFeature/Services/Index/ModPackIndexParser.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Services/Index/ModPackIndexParser.swift
@@ -22,6 +22,7 @@ enum ModPackIndexParser {
     }
 
     private static let adapters: [any ModPackIndexAdapter] = [
+        MMCIndexAdapter(),
         ModrinthIndexAdapter(),
         CurseForgeZipIndexAdapter(),
     ]

--- a/SwiftCraftLauncher/ModPackFeature/Services/ModPackInstallCoordinator.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Services/ModPackInstallCoordinator.swift
@@ -335,7 +335,7 @@ final class ModPackInstallCoordinator {
     private func calculateOverridesTotal(extractedPath: URL) async -> Int {
         var overridesPath = extractedPath.appendingPathComponent("overrides")
         if !FileManager.default.fileExists(atPath: overridesPath.path) {
-            let possiblePaths = ["overrides", "Override", "override"]
+            let possiblePaths = ["overrides", "Override", "override", "minecraft"]
             for pathName in possiblePaths {
                 let testPath = extractedPath.appendingPathComponent(pathName)
                 if FileManager.default.fileExists(atPath: testPath.path) {

--- a/SwiftCraftLauncher/ModPackFeature/Utilities/ModPackDependencyInstaller/ModPackDependencyInstaller+Overrides.swift
+++ b/SwiftCraftLauncher/ModPackFeature/Utilities/ModPackDependencyInstaller/ModPackDependencyInstaller+Overrides.swift
@@ -17,7 +17,7 @@ extension ModPackDependencyInstaller {
         var overridesPath = extractedPath.appendingPathComponent("overrides")
 
         if !FileManager.default.fileExists(atPath: overridesPath.path) {
-            let possiblePaths = ["overrides", "Override", "override"]
+            let possiblePaths = ["overrides", "Override", "override", "minecraft"]
 
             var foundPath: URL?
             for pathName in possiblePaths {

--- a/SwiftCraftLauncherTests/Fixtures/mmc/instance.cfg
+++ b/SwiftCraftLauncherTests/Fixtures/mmc/instance.cfg
@@ -1,0 +1,5 @@
+[General]
+name=My MMC Modpack
+iconKey=grass
+IntendedVersion=1.20.1
+IntendedType=Fabric

--- a/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_fabric.json
+++ b/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_fabric.json
@@ -1,0 +1,16 @@
+{
+  "formatVersion": 1,
+  "components": [
+    {
+      "uid": "net.minecraft",
+      "version": "1.20.1"
+    },
+    {
+      "uid": "net.fabricmc.fabric-loader",
+      "version": "0.14.21",
+      "important": true
+    }
+  ],
+  "name": "Fabric Test Pack",
+  "versionId": "1.0.0"
+}

--- a/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_forge.json
+++ b/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_forge.json
@@ -1,0 +1,16 @@
+{
+  "formatVersion": 1,
+  "components": [
+    {
+      "uid": "net.minecraft",
+      "version": "1.20.1"
+    },
+    {
+      "uid": "net.minecraftforge",
+      "version": "47.2.0",
+      "important": true
+    }
+  ],
+  "name": "Forge Test Pack",
+  "versionId": "2.0.0"
+}

--- a/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_neoforge.json
+++ b/SwiftCraftLauncherTests/Fixtures/mmc/mmc_pack_neoforge.json
@@ -1,0 +1,14 @@
+{
+  "formatVersion": 1,
+  "components": [
+    {
+      "uid": "net.minecraft",
+      "version": "1.20.4"
+    },
+    {
+      "uid": "net.neoforge",
+      "version": "20.4.23-beta",
+      "important": true
+    }
+  ]
+}

--- a/SwiftCraftLauncherTests/ModPackFeature/Utilities/MMCIndexAdapterTests.swift
+++ b/SwiftCraftLauncherTests/ModPackFeature/Utilities/MMCIndexAdapterTests.swift
@@ -1,0 +1,225 @@
+//
+//  MMCIndexAdapterTests.swift
+//  SwiftCraftLauncherTests
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+@testable import SwiftCraftLauncher
+import XCTest
+
+final class MMCIndexAdapterTests: XCTestCase {
+    private let adapter = MMCIndexAdapter()
+
+    func testCanParse_withMmcPackJson() async throws {
+        let directory = try await makeExtractedPackDirectory(
+            packJsonName: "mmc_pack_fabric",
+            hasInstanceCfg: false,
+        )
+
+        let result = await adapter.canParse(extractedPath: directory)
+        XCTAssertTrue(result)
+    }
+
+    func testCanParse_withoutMmcPackJson() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let result = await adapter.canParse(extractedPath: directory)
+        XCTAssertFalse(result)
+    }
+
+    func testCanParse_withInstanceCfgOnly() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cfgURL = directory.appendingPathComponent("instance.cfg")
+        try Data("name=Test".utf8).write(to: cfgURL)
+
+        let result = await adapter.canParse(extractedPath: directory)
+        XCTAssertFalse(result)
+    }
+
+    func testParse_fabricLoader() async throws {
+        let directory = try await makeExtractedPackDirectory(
+            packJsonName: "mmc_pack_fabric",
+            hasInstanceCfg: false,
+        )
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.gameVersion, "1.20.1")
+        XCTAssertEqual(result?.loaderType, GameLoader.fabric.displayName)
+        XCTAssertEqual(result?.loaderVersion, "0.14.21")
+        XCTAssertEqual(result?.modPackName, "Fabric Test Pack")
+        XCTAssertEqual(result?.modPackVersion, "1.0.0")
+        XCTAssertEqual(result?.source, .mmc)
+        XCTAssertTrue(result?.files.isEmpty ?? true)
+        XCTAssertTrue(result?.dependencies.isEmpty ?? true)
+    }
+
+    func testParse_forgeLoader() async throws {
+        let directory = try await makeExtractedPackDirectory(
+            packJsonName: "mmc_pack_forge",
+            hasInstanceCfg: false,
+        )
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.loaderType, GameLoader.forge.displayName)
+        XCTAssertEqual(result?.loaderVersion, "47.2.0")
+    }
+
+    func testParse_neoforgeLoader() async throws {
+        let directory = try await makeExtractedPackDirectory(
+            packJsonName: "mmc_pack_neoforge",
+            hasInstanceCfg: false,
+        )
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.loaderType, GameLoader.neoforge.displayName)
+        XCTAssertEqual(result?.loaderVersion, "20.4.23-beta")
+    }
+
+    func testParse_readsNameFromInstanceCfg() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let packJsonURL = TestSupport.fixtureURL(
+            subdirectory: "Fixtures/mmc",
+            name: "mmc_pack_fabric",
+            extension: "json",
+        )
+        try FileManager.default.copyItem(at: packJsonURL, to: directory.appendingPathComponent("mmc-pack.json"))
+
+        guard let cfgData = "[General]\nname=My MMC Modpack\niconKey=grass\n".data(using: .utf8) else {
+            XCTFail("Failed to create cfg data")
+            return
+        }
+        try cfgData.write(to: directory.appendingPathComponent("instance.cfg"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.modPackName, "My MMC Modpack")
+    }
+
+    func testParse_instanceCfgNameTakesPrecedenceOverPackJsonName() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let packJsonURL = TestSupport.fixtureURL(
+            subdirectory: "Fixtures/mmc",
+            name: "mmc_pack_fabric",
+            extension: "json",
+        )
+        try FileManager.default.copyItem(at: packJsonURL, to: directory.appendingPathComponent("mmc-pack.json"))
+
+        guard let cfgData = "[General]\nname=Config Name\n".data(using: .utf8) else {
+            XCTFail("Failed to create cfg data")
+            return
+        }
+        try cfgData.write(to: directory.appendingPathComponent("instance.cfg"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.modPackName, "Config Name")
+    }
+
+    func testParse_missingMinecraftComponent_returnsNil() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let packJson: [String: Any] = [
+            "formatVersion": 1,
+            "components": [
+                ["uid": "net.fabricmc.fabric-loader", "version": "0.14.21"],
+            ],
+        ]
+        let packJsonData = try JSONSerialization.data(withJSONObject: packJson)
+        try packJsonData.write(to: directory.appendingPathComponent("mmc-pack.json"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+        XCTAssertNil(result)
+    }
+
+    func testParse_vanillaWhenNoLoaderComponent() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let packJson: [String: Any] = [
+            "formatVersion": 1,
+            "components": [
+                ["uid": "net.minecraft", "version": "1.20.1"],
+            ],
+        ]
+        let packJsonData = try JSONSerialization.data(withJSONObject: packJson)
+        try packJsonData.write(to: directory.appendingPathComponent("mmc-pack.json"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.loaderType, GameLoader.vanilla.displayName)
+        XCTAssertEqual(result?.loaderVersion, "unknown")
+    }
+
+    func testParse_invalidJSON_returnsNil() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try Data("{".utf8).write(to: directory.appendingPathComponent("mmc-pack.json"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+        XCTAssertNil(result)
+    }
+
+    func testParse_quiltLoader() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let packJson: [String: Any] = [
+            "formatVersion": 1,
+            "components": [
+                ["uid": "net.minecraft", "version": "1.20.1"],
+                ["uid": "org.quiltmc.quilt-loader", "version": "0.19.0"],
+            ],
+        ]
+        let packJsonData = try JSONSerialization.data(withJSONObject: packJson)
+        try packJsonData.write(to: directory.appendingPathComponent("mmc-pack.json"))
+
+        let result = await adapter.parseToModrinthIndexInfo(extractedPath: directory)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.loaderType, GameLoader.quilt.rawValue)
+        XCTAssertEqual(result?.loaderVersion, "0.19.0")
+    }
+
+    private func makeExtractedPackDirectory(
+        packJsonName: String,
+        hasInstanceCfg: Bool,
+    ) async throws -> URL {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        let packJsonURL = TestSupport.fixtureURL(
+            subdirectory: "Fixtures/mmc",
+            name: packJsonName,
+            extension: "json",
+        )
+        try FileManager.default.copyItem(at: packJsonURL, to: directory.appendingPathComponent("mmc-pack.json"))
+
+        if hasInstanceCfg {
+            let cfgURL = TestSupport.fixtureURL(
+                subdirectory: "Fixtures/mmc",
+                name: "instance",
+                extension: "cfg",
+            )
+            try FileManager.default.copyItem(at: cfgURL, to: directory.appendingPathComponent("instance.cfg"))
+        }
+
+        return directory
+    }
+}

--- a/SwiftCraftLauncherTests/TestSupport.swift
+++ b/SwiftCraftLauncherTests/TestSupport.swift
@@ -39,6 +39,16 @@ enum TestSupport {
             return url
         }
 
+        // Fallback: load from source tree relative to TestSupport.swift.
+        let sourceFixtures = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent(subdirectory)
+            .appendingPathComponent("\(name).\(ext)")
+        if FileManager.default.fileExists(atPath: sourceFixtures.path) {
+            return sourceFixtures
+        }
+
         XCTFail("Missing fixture \(subdirectory)/\(name).\(ext)")
         fatalError("Missing fixture \(subdirectory)/\(name).\(ext)")
     }


### PR DESCRIPTION
## Summary by Sourcery

Add MultiMC and PrismLauncher modpack import support.

New Features:
- Add support for importing MultiMC and PrismLauncher modpack archives, including Minecraft and loader metadata for Fabric, Forge, NeoForge, Quilt, and vanilla packs.

Enhancements:
- Handle MMC instance names and treat the standard minecraft directory as the pack overrides location.
- Prevent failed-resource resolution attempts for MMC files that lack centralized project metadata.

Tests:
- Add coverage for MMC archive detection, metadata parsing, loader variants, naming precedence, invalid packs, and missing required components.

Chores:
- Improve test fixture lookup with a source-tree fallback.