### PR TITLE
fix(world):修复世界详情页滚动条闪烁

### DIFF
--- a/SwiftCraftLauncher/GameFeature/Views/SaveInfo/WorldDetailSheetView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/SaveInfo/WorldDetailSheetView.swift
@@ -51,26 +51,24 @@ struct WorldDetailSheetView: View {
     }
 
     private func metadataContentView(metadata: WorldDetailMetadata) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                HStack(alignment: .top, spacing: 24) {
-                    WorldDetailBasicInfoSectionView(metadata: metadata)
-                    WorldDetailGameSettingsSectionView(metadata: metadata)
-                }
-                if let seed = metadata.seed {
-                    SeedCopyRow(seed: seed)
-                }
-                WorldDetailOtherInfoSectionView(metadata: metadata)
-                WorldDetailPathRowView(worldPath: metadata.path)
-                if let filteredRaw = viewModel.filteredRawData {
-                    WorldDetailRawDataToggleView(
-                        filteredRawData: filteredRaw,
-                        showRawData: $viewModel.showRawData,
-                    )
-                }
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .top, spacing: 24) {
+                WorldDetailBasicInfoSectionView(metadata: metadata)
+                WorldDetailGameSettingsSectionView(metadata: metadata)
             }
-            .padding(.vertical, 8)
+            if let seed = metadata.seed {
+                SeedCopyRow(seed: seed)
+            }
+            WorldDetailOtherInfoSectionView(metadata: metadata)
+            WorldDetailPathRowView(worldPath: metadata.path)
+            if let filteredRaw = viewModel.filteredRawData {
+                WorldDetailRawDataToggleView(
+                    filteredRawData: filteredRaw,
+                    showRawData: $viewModel.showRawData,
+                )
+            }
         }
+        .padding(.vertical, 8)
     }
 
     private var footerView: some View {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent scrollbar flickering on the world details page by removing the nested scroll container from the metadata content.