### PR TITLE
feat(game):支持直接编辑游戏名称

### DIFF
--- a/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
+++ b/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
@@ -242,6 +242,42 @@ class GameRepository: @unchecked Sendable {
         }.value
     }
 
+    /// Renames a game and its profile directory in the current working path.
+    func renameGame(id: String, to newName: String) async throws {
+        let trimmedName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var game = getGame(by: id), !trimmedName.isEmpty, trimmedName != game.gameName else { return }
+        guard try await !gameNameExists(trimmedName, excludingID: id) else {
+            throw GlobalError.validation(
+                i18nKey: "game.form.name.duplicate",
+                level: .notification,
+            )
+        }
+
+        let oldDirectory = AppPaths.profileDirectory(gameName: game.gameName)
+        let newDirectory = AppPaths.profileDirectory(gameName: trimmedName)
+        guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
+            throw GlobalError.validation(
+                i18nKey: "game.form.name.duplicate",
+                level: .notification,
+            )
+        }
+
+        if FileManager.default.fileExists(atPath: oldDirectory.path) {
+            try FileManager.default.moveItem(at: oldDirectory, to: newDirectory)
+        }
+        game.gameName = trimmedName
+
+        do {
+            try await updateGame(game)
+        } catch {
+            if FileManager.default.fileExists(atPath: newDirectory.path),
+               !FileManager.default.fileExists(atPath: oldDirectory.path) {
+                try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
+            }
+            throw error
+        }
+    }
+
     func updateGame(_ game: GameVersionInfo) async throws {
         let workingPath = currentWorkingPath
         let gameToSave = game

--- a/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
+++ b/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
@@ -229,6 +229,19 @@ class GameRepository: @unchecked Sendable {
         games.first { $0.gameName == gameName }
     }
 
+    /// Checks whether a game name is already used in the current working path.
+    func gameNameExists(_ gameName: String, excludingID: String) async throws -> Bool {
+        let workingPath = currentWorkingPath
+        return try await Task.detached(priority: .userInitiated) {
+            try self.database.initialize()
+            return try self.database.gameNameExists(
+                workingPath: workingPath,
+                gameName: gameName,
+                excludingID: excludingID,
+            )
+        }.value
+    }
+
     func updateGame(_ game: GameVersionInfo) async throws {
         let workingPath = currentWorkingPath
         let gameToSave = game

--- a/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
+++ b/SwiftCraftLauncher/GameFeature/Data/GameRepository.swift
@@ -229,29 +229,10 @@ class GameRepository: @unchecked Sendable {
         games.first { $0.gameName == gameName }
     }
 
-    /// Checks whether a game name is already used in the current working path.
-    func gameNameExists(_ gameName: String, excludingID: String) async throws -> Bool {
-        let workingPath = currentWorkingPath
-        return try await Task.detached(priority: .userInitiated) {
-            try self.database.initialize()
-            return try self.database.gameNameExists(
-                workingPath: workingPath,
-                gameName: gameName,
-                excludingID: excludingID,
-            )
-        }.value
-    }
-
     /// Renames a game and its profile directory in the current working path.
     func renameGame(id: String, to newName: String) async throws {
         let trimmedName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard var game = getGame(by: id), !trimmedName.isEmpty, trimmedName != game.gameName else { return }
-        guard try await !gameNameExists(trimmedName, excludingID: id) else {
-            throw GlobalError.validation(
-                i18nKey: "game.form.name.duplicate",
-                level: .notification,
-            )
-        }
 
         let oldDirectory = AppPaths.profileDirectory(gameName: game.gameName)
         let newDirectory = AppPaths.profileDirectory(gameName: trimmedName)

--- a/SwiftCraftLauncher/GameFeature/Data/GameVersionDatabase.swift
+++ b/SwiftCraftLauncher/GameFeature/Data/GameVersionDatabase.swift
@@ -25,6 +25,7 @@ class GameVersionDatabase {
     private let deleteByIdSQL: String
     private let deleteByPathSQL: String
     private let deleteByPathAndNameSQL: String
+    private let existsByPathAndNameSQL: String
     private let updateLastPlayedSQL: String
 
     init(dbPath: String) {
@@ -54,6 +55,11 @@ class GameVersionDatabase {
         deleteByIdSQL = "DELETE FROM \(tableName) WHERE id = ?"
         deleteByPathSQL = "DELETE FROM \(tableName) WHERE working_path = ?"
         deleteByPathAndNameSQL = "DELETE FROM \(tableName) WHERE working_path = ? AND game_name = ?"
+        existsByPathAndNameSQL = """
+        SELECT 1 FROM \(tableName)
+        WHERE working_path = ? AND game_name = ? AND id != ?
+        LIMIT 1
+        """
         updateLastPlayedSQL = """
         UPDATE \(tableName)
         SET data_json = json_set(data_json, '$.lastPlayed', ?),
@@ -215,6 +221,16 @@ class GameVersionDatabase {
             }
         }
         return result
+    }
+
+    /// Checks whether a game name is already used in a working path.
+    func gameNameExists(workingPath: String, gameName: String, excludingID: String) throws -> Bool {
+        try withPreparedStatement(existsByPathAndNameSQL) { statement in
+            SQLiteDatabase.bind(statement, index: 1, value: workingPath)
+            SQLiteDatabase.bind(statement, index: 2, value: gameName)
+            SQLiteDatabase.bind(statement, index: 3, value: excludingID)
+            return sqlite3_step(statement) == SQLITE_ROW
+        }
     }
 
     /// Deletes a game by its identifier.

--- a/SwiftCraftLauncher/GameFeature/Data/GameVersionDatabase.swift
+++ b/SwiftCraftLauncher/GameFeature/Data/GameVersionDatabase.swift
@@ -25,7 +25,6 @@ class GameVersionDatabase {
     private let deleteByIdSQL: String
     private let deleteByPathSQL: String
     private let deleteByPathAndNameSQL: String
-    private let existsByPathAndNameSQL: String
     private let updateLastPlayedSQL: String
 
     init(dbPath: String) {
@@ -55,11 +54,6 @@ class GameVersionDatabase {
         deleteByIdSQL = "DELETE FROM \(tableName) WHERE id = ?"
         deleteByPathSQL = "DELETE FROM \(tableName) WHERE working_path = ?"
         deleteByPathAndNameSQL = "DELETE FROM \(tableName) WHERE working_path = ? AND game_name = ?"
-        existsByPathAndNameSQL = """
-        SELECT 1 FROM \(tableName)
-        WHERE working_path = ? AND game_name = ? AND id != ?
-        LIMIT 1
-        """
         updateLastPlayedSQL = """
         UPDATE \(tableName)
         SET data_json = json_set(data_json, '$.lastPlayed', ?),
@@ -221,16 +215,6 @@ class GameVersionDatabase {
             }
         }
         return result
-    }
-
-    /// Checks whether a game name is already used in a working path.
-    func gameNameExists(workingPath: String, gameName: String, excludingID: String) throws -> Bool {
-        try withPreparedStatement(existsByPathAndNameSQL) { statement in
-            SQLiteDatabase.bind(statement, index: 1, value: workingPath)
-            SQLiteDatabase.bind(statement, index: 2, value: gameName)
-            SQLiteDatabase.bind(statement, index: 3, value: excludingID)
-            return sqlite3_step(statement) == SQLITE_ROW
-        }
     }
 
     /// Deletes a game by its identifier.

--- a/SwiftCraftLauncher/GameFeature/Models/GameVersionInfo.swift
+++ b/SwiftCraftLauncher/GameFeature/Models/GameVersionInfo.swift
@@ -14,7 +14,7 @@ struct GameVersionInfo: Codable, Identifiable, Hashable, Sendable {
     let id: String
 
     /// The display name of the game.
-    let gameName: String
+    var gameName: String
 
     /// The path or URL of the game icon.
     var gameIcon: String

--- a/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
+++ b/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
@@ -21,4 +21,17 @@ final class GameHeaderViewModel {
             atPath: AppPaths.profileDirectory(gameName: trimmed).path,
         )
     }
+
+    func performRename(gameId: String, currentName _: String, gameRepository: GameRepository) async {
+        guard !isRenaming else { return }
+        isRenaming = true
+        defer { isRenaming = false }
+
+        do {
+            let trimmedName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+            try await gameRepository.renameGame(id: gameId, to: trimmedName)
+        } catch {
+            DIContainer.shared.core.errorHandler.handle(error)
+        }
+    }
 }

--- a/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
+++ b/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  GameHeaderViewModel.swift
+//  GameFeature
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class GameHeaderViewModel {
+    var newName = ""
+    var isRenaming = false
+
+    func isNameValid(newName: String, currentName: String) -> Bool {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != currentName else { return false }
+        return !FileManager.default.fileExists(
+            atPath: AppPaths.profileDirectory(gameName: trimmed).path,
+        )
+    }
+}

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
@@ -13,6 +13,8 @@ import SwiftUI
 struct GameHeaderListRow: View {
     @Environment(DIContainer.self)
     private var container
+    @Environment(GameRepository.self)
+    private var gameRepository
     private static let iconSize: CGFloat = 80
     private static let iconPaddingRatio: CGFloat = 0.125
     private static let iconCornerRadiusRatio: CGFloat = 0.2
@@ -20,30 +22,23 @@ struct GameHeaderListRow: View {
     let game: GameVersionInfo
     let cacheInfo: CacheInfo
     let query: String
-    @Binding var isNameEditorPresented: Bool
-    let nameEditorContent: AnyView
     var onIconTap: (() -> Void)?
-    var onNameTap: (() -> Void)?
 
     @State private var refreshTrigger: UUID = .init()
     @State private var cancellable: AnyCancellable?
+    @State private var showRenamePopover = false
+    @State private var viewModel = GameHeaderViewModel()
 
     init(
         game: GameVersionInfo,
         cacheInfo: CacheInfo,
         query: String,
-        isNameEditorPresented: Binding<Bool>,
-        nameEditorContent: AnyView,
         onIconTap: (() -> Void)? = nil,
-        onNameTap: (() -> Void)? = nil,
     ) {
         self.game = game
         self.cacheInfo = cacheInfo
         self.query = query
-        _isNameEditorPresented = isNameEditorPresented
-        self.nameEditorContent = nameEditorContent
         self.onIconTap = onIconTap
-        self.onNameTap = onNameTap
     }
 
     var body: some View {
@@ -51,15 +46,16 @@ struct GameHeaderListRow: View {
             gameIcon
             VStack(alignment: .leading, spacing: 4) {
                 Button {
-                    onNameTap?()
+                    viewModel.newName = game.gameName
+                    showRenamePopover = true
                 } label: {
                     Text(game.gameName)
                         .font(.title)
                         .bold()
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        .popover(isPresented: $isNameEditorPresented, arrowEdge: .top) {
-                            nameEditorContent
+                        .popover(isPresented: $showRenamePopover, arrowEdge: .top) {
+                            renamePopover
                         }
                 }
                 .buttonStyle(.plain)
@@ -104,6 +100,45 @@ struct GameHeaderListRow: View {
         .listRowInsets(
             EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 8),
         )
+    }
+
+    private var renamePopover: some View {
+        @Bindable var viewModel = viewModel
+
+        return HStack(spacing: 8) {
+            TextField("game.form.name.placeholder".localized(), text: $viewModel.newName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(renameGame)
+            Button("common.confirm".localized(), action: renameGame)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canRename)
+        }
+        .padding()
+        .frame(width: 500)
+    }
+
+    private var canRename: Bool {
+        viewModel.isNameValid(newName: viewModel.newName, currentName: game.gameName)
+            && !viewModel.isRenaming
+            && !container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
+    }
+
+    private func renameGame() {
+        guard canRename else { return }
+        let newName = viewModel.newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        viewModel.isRenaming = true
+
+        Task { @MainActor in
+            defer { viewModel.isRenaming = false }
+            do {
+                guard !container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id) else { return }
+                try await gameRepository.renameGame(id: game.id, to: newName)
+                showRenamePopover = false
+                container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
+            } catch {
+                container.core.errorHandler.handle(GlobalError.from(error))
+            }
+        }
     }
 
     /// The URL of the icon file in the game profile directory.

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
@@ -20,6 +20,8 @@ struct GameHeaderListRow: View {
     let game: GameVersionInfo
     let cacheInfo: CacheInfo
     let query: String
+    @Binding var isNameEditorPresented: Bool
+    let nameEditorContent: AnyView
     var onIconTap: (() -> Void)?
     var onNameTap: (() -> Void)?
 
@@ -30,12 +32,16 @@ struct GameHeaderListRow: View {
         game: GameVersionInfo,
         cacheInfo: CacheInfo,
         query: String,
+        isNameEditorPresented: Binding<Bool>,
+        nameEditorContent: AnyView,
         onIconTap: (() -> Void)? = nil,
         onNameTap: (() -> Void)? = nil,
     ) {
         self.game = game
         self.cacheInfo = cacheInfo
         self.query = query
+        _isNameEditorPresented = isNameEditorPresented
+        self.nameEditorContent = nameEditorContent
         self.onIconTap = onIconTap
         self.onNameTap = onNameTap
     }
@@ -44,17 +50,21 @@ struct GameHeaderListRow: View {
         HStack {
             gameIcon
             VStack(alignment: .leading, spacing: 4) {
-                Text(game.gameName)
-                    .font(.title)
-                    .bold()
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: 400, alignment: .leading)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        onNameTap?()
-                    }
-                    .applyPointerHandIfAvailable()
+                Button {
+                    onNameTap?()
+                } label: {
+                    Text(game.gameName)
+                        .font(.title)
+                        .bold()
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .popover(isPresented: $isNameEditorPresented, arrowEdge: .top) {
+                            nameEditorContent
+                        }
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: 400, alignment: .leading)
+                .applyPointerHandIfAvailable()
 
                 HStack(spacing: 8) {
                     Label(game.gameVersion, systemImage: "gamecontroller.fill")

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
@@ -45,22 +45,21 @@ struct GameHeaderListRow: View {
         HStack {
             gameIcon
             VStack(alignment: .leading, spacing: 4) {
-                Button {
-                    viewModel.newName = game.gameName
-                    showRenamePopover = true
-                } label: {
-                    Text(game.gameName)
-                        .font(.title)
-                        .bold()
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .popover(isPresented: $showRenamePopover, arrowEdge: .top) {
-                            renamePopover
-                        }
-                }
-                .buttonStyle(.plain)
-                .frame(maxWidth: 400, alignment: .leading)
-                .applyPointerHandIfAvailable()
+                Text(game.gameName)
+                    .font(.title)
+                    .bold()
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 400, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        viewModel.newName = game.gameName
+                        showRenamePopover = true
+                    }
+                    .popover(isPresented: $showRenamePopover) {
+                        renamePopover
+                    }
+                    .applyPointerHandIfAvailable()
 
                 HStack(spacing: 8) {
                     Label(game.gameVersion, systemImage: "gamecontroller.fill")
@@ -108,37 +107,28 @@ struct GameHeaderListRow: View {
         return HStack(spacing: 8) {
             TextField("game.form.name.placeholder".localized(), text: $viewModel.newName)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit(renameGame)
-            Button("common.confirm".localized(), action: renameGame)
-                .buttonStyle(.borderedProminent)
-                .disabled(!canRename)
+            Button("common.confirm".localized()) {
+                Task {
+                    await viewModel.performRename(
+                        gameId: game.id,
+                        currentName: game.gameName,
+                        gameRepository: gameRepository,
+                    )
+                    showRenamePopover = false
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(
+                viewModel.isRenaming
+                    || !viewModel.isNameValid(
+                        newName: viewModel.newName,
+                        currentName: game.gameName,
+                    ),
+            )
+            .keyboardShortcut(.defaultAction)
         }
         .padding()
-        .frame(width: 500)
-    }
-
-    private var canRename: Bool {
-        viewModel.isNameValid(newName: viewModel.newName, currentName: game.gameName)
-            && !viewModel.isRenaming
-            && !container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
-    }
-
-    private func renameGame() {
-        guard canRename else { return }
-        let newName = viewModel.newName.trimmingCharacters(in: .whitespacesAndNewlines)
-        viewModel.isRenaming = true
-
-        Task { @MainActor in
-            defer { viewModel.isRenaming = false }
-            do {
-                guard !container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id) else { return }
-                try await gameRepository.renameGame(id: game.id, to: newName)
-                showRenamePopover = false
-                container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
-            } catch {
-                container.core.errorHandler.handle(GlobalError.from(error))
-            }
-        }
+        .frame(width: 400)
     }
 
     /// The URL of the icon file in the game profile directory.

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
@@ -21,6 +21,7 @@ struct GameHeaderListRow: View {
     let cacheInfo: CacheInfo
     let query: String
     var onIconTap: (() -> Void)?
+    var onNameTap: (() -> Void)?
 
     @State private var refreshTrigger: UUID = .init()
     @State private var cancellable: AnyCancellable?
@@ -30,11 +31,13 @@ struct GameHeaderListRow: View {
         cacheInfo: CacheInfo,
         query: String,
         onIconTap: (() -> Void)? = nil,
+        onNameTap: (() -> Void)? = nil,
     ) {
         self.game = game
         self.cacheInfo = cacheInfo
         self.query = query
         self.onIconTap = onIconTap
+        self.onNameTap = onNameTap
     }
 
     var body: some View {
@@ -47,6 +50,11 @@ struct GameHeaderListRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: 400, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onNameTap?()
+                    }
+                    .applyPointerHandIfAvailable()
 
                 HStack(spacing: 8) {
                     Label(game.gameVersion, systemImage: "gamecontroller.fill")

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -33,6 +33,7 @@ struct GameInfoDetailView: View {
     @State private var ioViewModel = GameInfoDetailIOViewModel()
 
     @State private var scannedResources: Set<String> = []
+    @State private var header: AnyView?
     @State private var showIconFilePicker = false
 
     init(
@@ -103,6 +104,12 @@ struct GameInfoDetailView: View {
         .onChange(of: game.gameName) { _, _ in
             performRefresh()
         }
+        .onChange(of: game.modLoader) { _, _ in
+            updateHeaders()
+        }
+        .onChange(of: game.modVersion) { _, _ in
+            updateHeaders()
+        }
         .onChange(of: gameType) { _, _ in
             performRefresh()
         }
@@ -127,7 +134,11 @@ struct GameInfoDetailView: View {
             }
         }
         .onAppear {
+            updateHeaders()
             container.core.cacheInfoManager.calculateGameCacheInfo(game.gameName)
+        }
+        .onChange(of: container.core.cacheInfoManager.cacheInfo) { _, _ in
+            updateHeaders()
         }
         .onDisappear {
             clearAllData()
@@ -142,6 +153,7 @@ struct GameInfoDetailView: View {
     }
 
     private func performRefresh() {
+        updateHeaders()
         container.core.cacheInfoManager.calculateGameCacheInfo(game.gameName)
         if !gameType {
             triggerLocalRefresh()
@@ -155,10 +167,10 @@ struct GameInfoDetailView: View {
         localRefreshToken = UUID()
     }
 
-    private var header: AnyView {
+    private func updateHeaders() {
         let currentGame = gameRepository.games.first { $0.id == game.id } ?? game
 
-        return AnyView(
+        header = AnyView(
             GameHeaderListRow(
                 game: currentGame,
                 cacheInfo: container.core.cacheInfoManager.cacheInfo,

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -177,14 +177,11 @@ struct GameInfoDetailView: View {
                 game: currentGame,
                 cacheInfo: container.core.cacheInfoManager.cacheInfo,
                 query: query,
-            ) {
-                showIconFilePicker = true
-            } onNameTap: {
-                beginGameNameEditing()
-            }
-            .popover(isPresented: $showGameNamePopover, arrowEdge: .bottom) {
-                gameNameEditorPopover
-            },
+                isNameEditorPresented: $showGameNamePopover,
+                nameEditorContent: AnyView(gameNameEditorPopover),
+                onIconTap: { showIconFilePicker = true },
+                onNameTap: beginGameNameEditing,
+            ),
         )
     }
 

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -6,6 +6,7 @@
 //
 
 // Displays game information details with local and remote resource browsing.
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -177,8 +178,76 @@ struct GameInfoDetailView: View {
                 query: query,
             ) {
                 showIconFilePicker = true
+            } onNameTap: {
+                presentGameNameEditor()
             },
         )
+    }
+
+    private func presentGameNameEditor() {
+        let alert = NSAlert()
+        alert.messageText = "game.form.name".localized()
+        alert.informativeText = "game.form.name.placeholder".localized()
+
+        let textField = NSTextField(string: game.gameName)
+        textField.placeholderString = "game.form.name.placeholder".localized()
+        textField.frame = NSRect(x: 0, y: 0, width: 280, height: 24)
+        alert.accessoryView = textField
+        alert.addButton(withTitle: "common.confirm".localized())
+        alert.addButton(withTitle: "common.cancel".localized())
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let newName = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newName.isEmpty else { return }
+        guard !gameRepository.games.contains(where: { $0.id != game.id && $0.gameName == newName }) else {
+            container.core.errorHandler.handle(
+                GlobalError.validation(
+                    i18nKey: "game.form.name.duplicate",
+                    level: .notification,
+                ),
+            )
+            return
+        }
+
+        guard var updatedGame = gameRepository.games.first(where: { $0.id == game.id }) else { return }
+        let oldDirectory = AppPaths.profileDirectory(gameName: updatedGame.gameName)
+        let newDirectory = AppPaths.profileDirectory(gameName: newName)
+
+        do {
+            if updatedGame.gameName != newName {
+                guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
+                    throw GlobalError.validation(
+                        i18nKey: "game.form.name.duplicate",
+                        level: .notification,
+                    )
+                }
+                if FileManager.default.fileExists(atPath: oldDirectory.path) {
+                    try FileManager.default.moveItem(at: oldDirectory, to: newDirectory)
+                }
+            }
+
+            updatedGame.gameName = newName
+            Task { @MainActor in
+                do {
+                    try await gameRepository.updateGame(updatedGame)
+                    container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
+                    performRefresh()
+                } catch {
+                    if FileManager.default.fileExists(atPath: newDirectory.path),
+                       !FileManager.default.fileExists(atPath: oldDirectory.path) {
+                        try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
+                    }
+                    container.core.errorHandler.handle(GlobalError.from(error))
+                }
+            }
+        } catch {
+            if FileManager.default.fileExists(atPath: newDirectory.path),
+               !FileManager.default.fileExists(atPath: oldDirectory.path) {
+                try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
+            }
+            container.core.errorHandler.handle(GlobalError.from(error))
+        }
     }
 
     private func clearAllData() {

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -10,14 +10,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct GameInfoDetailView: View {
-    private enum NameValidationState: Equatable {
-        case idle
-        case checking
-        case valid
-        case duplicate
-        case failed(String)
-    }
-
     @Environment(DIContainer.self)
     private var container
     let game: GameVersionInfo
@@ -42,12 +34,6 @@ struct GameInfoDetailView: View {
 
     @State private var scannedResources: Set<String> = []
     @State private var showIconFilePicker = false
-    @State private var showGameNamePopover = false
-    @State private var editedGameName = ""
-    @State private var nameValidationState: NameValidationState = .idle
-    @State private var nameValidationRequestID = UUID()
-    @State private var isSavingGameName = false
-    @State private var isGameRunningForNameEdit = false
 
     init(
         game: GameVersionInfo,
@@ -177,141 +163,10 @@ struct GameInfoDetailView: View {
                 game: currentGame,
                 cacheInfo: container.core.cacheInfoManager.cacheInfo,
                 query: query,
-                isNameEditorPresented: $showGameNamePopover,
-                nameEditorContent: AnyView(gameNameEditorPopover),
-                onIconTap: { showIconFilePicker = true },
-                onNameTap: beginGameNameEditing,
-            ),
+            ) {
+                showIconFilePicker = true
+            },
         )
-    }
-
-    private var gameNameEditorPopover: some View {
-        HStack(spacing: 12) {
-            TextField("game.form.name.placeholder".localized(), text: $editedGameName)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 340)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(nameValidationMessage == nil ? Color.clear : Color.red, lineWidth: 1)
-                }
-                .help(nameValidationMessage ?? "")
-                .onSubmit {
-                    guard canConfirmGameName else { return }
-                    saveGameName()
-                }
-            Button("common.confirm".localized(), action: saveGameName)
-                .buttonStyle(.borderedProminent)
-                .disabled(!canConfirmGameName)
-        }
-        .padding()
-        .onChange(of: editedGameName) { _, newValue in
-            validateEditedGameName(newValue)
-        }
-    }
-
-    private var nameValidationMessage: String? {
-        switch nameValidationState {
-        case .duplicate:
-            "game.form.name.duplicate".localized()
-        case let .failed(message):
-            message
-        case .idle, .checking, .valid:
-            nil
-        }
-    }
-
-    private func beginGameNameEditing() {
-        editedGameName = currentGameName
-        nameValidationState = .idle
-        nameValidationRequestID = UUID()
-        isGameRunningForNameEdit = isCurrentGameRunning
-        showGameNamePopover = true
-    }
-
-    private var currentGameName: String {
-        gameRepository.getGame(by: game.id)?.gameName ?? game.gameName
-    }
-
-    private var isCurrentGameRunning: Bool {
-        container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
-    }
-
-    private var canConfirmGameName: Bool {
-        nameValidationState == .valid
-            && !isSavingGameName
-            && !isGameRunningForNameEdit
-    }
-
-    private func validateEditedGameName(_ value: String) {
-        let newName = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        let requestID = UUID()
-        nameValidationRequestID = requestID
-
-        guard !newName.isEmpty, newName != currentGameName else {
-            nameValidationState = .idle
-            return
-        }
-
-        nameValidationState = .checking
-        Task { @MainActor in
-            do {
-                let exists = try await gameRepository.gameNameExists(newName, excludingID: game.id)
-                guard requestID == nameValidationRequestID else { return }
-                nameValidationState = exists ? .duplicate : .valid
-            } catch {
-                guard requestID == nameValidationRequestID else { return }
-                nameValidationState = .failed(GlobalError.from(error).localizedDescription)
-            }
-        }
-    }
-
-    private func saveGameName() {
-        guard canConfirmGameName else { return }
-        let newName = editedGameName.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        isSavingGameName = true
-        Task { @MainActor in
-            defer { isSavingGameName = false }
-            do {
-                guard !isCurrentGameRunning else {
-                    isGameRunningForNameEdit = true
-                    return
-                }
-                guard var updatedGame = gameRepository.getGame(by: game.id) else { return }
-                guard try await !gameRepository.gameNameExists(newName, excludingID: game.id) else {
-                    nameValidationState = .duplicate
-                    return
-                }
-
-                let oldDirectory = AppPaths.profileDirectory(gameName: updatedGame.gameName)
-                let newDirectory = AppPaths.profileDirectory(gameName: newName)
-                guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
-                    nameValidationState = .duplicate
-                    return
-                }
-
-                if FileManager.default.fileExists(atPath: oldDirectory.path) {
-                    try FileManager.default.moveItem(at: oldDirectory, to: newDirectory)
-                }
-                updatedGame.gameName = newName
-
-                do {
-                    try await gameRepository.updateGame(updatedGame)
-                } catch {
-                    if FileManager.default.fileExists(atPath: newDirectory.path),
-                       !FileManager.default.fileExists(atPath: oldDirectory.path) {
-                        try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
-                    }
-                    throw error
-                }
-
-                showGameNamePopover = false
-                container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
-                performRefresh()
-            } catch {
-                container.core.errorHandler.handle(GlobalError.from(error))
-            }
-        }
     }
 
     private func clearAllData() {

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -6,7 +6,6 @@
 //
 
 // Displays game information details with local and remote resource browsing.
-import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -27,6 +26,8 @@ struct GameInfoDetailView: View {
     @Binding var gameType: Bool
     @Environment(GameRepository.self)
     private var gameRepository
+    @Environment(PlayerListViewModel.self)
+    private var playerListViewModel
     @Binding var selectedItem: SidebarItem
     @Binding var searchText: String
     @Binding var localResourceFilter: LocalResourceFilter
@@ -36,6 +37,12 @@ struct GameInfoDetailView: View {
     @State private var scannedResources: Set<String> = []
     @State private var header: AnyView?
     @State private var showIconFilePicker = false
+    @State private var showGameNamePopover = false
+    @State private var editedGameName = ""
+    @State private var nameEditorError: String?
+    @State private var isNameDuplicate = false
+    @State private var isCheckingName = false
+    @State private var isSavingGameName = false
 
     init(
         game: GameVersionInfo,
@@ -171,82 +178,155 @@ struct GameInfoDetailView: View {
     private func updateHeaders() {
         let currentGame = gameRepository.games.first { $0.id == game.id } ?? game
 
-        header = AnyView(
-            GameHeaderListRow(
-                game: currentGame,
-                cacheInfo: container.core.cacheInfoManager.cacheInfo,
-                query: query,
-            ) {
-                showIconFilePicker = true
-            } onNameTap: {
-                presentGameNameEditor()
-            },
-        )
+        let headerView = GameHeaderListRow(
+            game: currentGame,
+            cacheInfo: container.core.cacheInfoManager.cacheInfo,
+            query: query,
+        ) {
+            showIconFilePicker = true
+        } onNameTap: {
+            beginGameNameEditing()
+        }
+        .popover(isPresented: $showGameNamePopover, arrowEdge: .bottom) {
+            gameNameEditorPopover
+        }
+        header = AnyView(headerView)
     }
 
-    private func presentGameNameEditor() {
-        let alert = NSAlert()
-        alert.messageText = "game.form.name".localized()
-        alert.informativeText = "game.form.name.placeholder".localized()
+    private var gameNameEditorPopover: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("game.form.name".localized())
+                .font(.headline)
+            TextField("game.form.name.placeholder".localized(), text: $editedGameName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(saveGameName)
+            if isNameDuplicate {
+                Text("game.form.name.duplicate".localized())
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            } else if let nameEditorError {
+                Text(nameEditorError)
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            }
+            HStack {
+                Spacer()
+                Button("common.confirm".localized(), action: saveGameName)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(
+                        isSavingGameName
+                            || isCurrentGameRunning
+                            || isCurrentGameLaunching
+                            || isCheckingName
+                            || isNameDuplicate
+                            || editedGameName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || editedGameName == game.gameName,
+                    )
+            }
+        }
+        .padding()
+        .frame(width: 300)
+        .task(id: editedGameName) {
+            await validateEditedGameName()
+        }
+    }
 
-        let textField = NSTextField(string: game.gameName)
-        textField.placeholderString = "game.form.name.placeholder".localized()
-        textField.frame = NSRect(x: 0, y: 0, width: 280, height: 24)
-        alert.accessoryView = textField
-        alert.addButton(withTitle: "common.confirm".localized())
-        alert.addButton(withTitle: "common.cancel".localized())
+    private func beginGameNameEditing() {
+        editedGameName = game.gameName
+        nameEditorError = nil
+        isNameDuplicate = false
+        showGameNamePopover = true
+    }
 
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
+    private var currentUserID: String {
+        playerListViewModel.currentPlayer?.id ?? ""
+    }
 
-        let newName = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !newName.isEmpty else { return }
-        guard !gameRepository.games.contains(where: { $0.id != game.id && $0.gameName == newName }) else {
-            container.core.errorHandler.handle(
-                GlobalError.validation(
-                    i18nKey: "game.form.name.duplicate",
-                    level: .notification,
-                ),
-            )
+    private var isCurrentGameRunning: Bool {
+        container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
+    }
+
+    private var isCurrentGameLaunching: Bool {
+        container.core.gameStatusManager.isGameLaunching(gameId: game.id, userId: currentUserID)
+    }
+
+    private func validateEditedGameName() async {
+        let newName = editedGameName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newName.isEmpty, newName != game.gameName else {
+            isNameDuplicate = false
+            isCheckingName = false
             return
         }
 
-        guard var updatedGame = gameRepository.games.first(where: { $0.id == game.id }) else { return }
-        let oldDirectory = AppPaths.profileDirectory(gameName: updatedGame.gameName)
-        let newDirectory = AppPaths.profileDirectory(gameName: newName)
-
+        isCheckingName = true
         do {
-            if updatedGame.gameName != newName {
-                guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
-                    throw GlobalError.validation(
-                        i18nKey: "game.form.name.duplicate",
-                        level: .notification,
-                    )
+            let exists = try await gameRepository.gameNameExists(newName, excludingID: game.id)
+            guard !Task.isCancelled else { return }
+            isNameDuplicate = exists
+        } catch {
+            guard !Task.isCancelled else { return }
+            isNameDuplicate = true
+            nameEditorError = GlobalError.from(error).localizedDescription
+        }
+        isCheckingName = false
+    }
+
+    private func saveGameName() {
+        guard !isSavingGameName else { return }
+        let newName = editedGameName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newName.isEmpty, newName != game.gameName else { return }
+
+        isSavingGameName = true
+        nameEditorError = nil
+        Task { @MainActor in
+            do {
+                guard !isCurrentGameRunning, !isCurrentGameLaunching else {
+                    isSavingGameName = false
+                    return
                 }
+                guard var updatedGame = gameRepository.getGame(by: game.id) else {
+                    isSavingGameName = false
+                    return
+                }
+                guard try await !gameRepository.gameNameExists(newName, excludingID: game.id) else {
+                    isNameDuplicate = true
+                    nameEditorError = "game.form.name.duplicate".localized()
+                    isSavingGameName = false
+                    return
+                }
+
+                let oldDirectory = AppPaths.profileDirectory(gameName: updatedGame.gameName)
+                let newDirectory = AppPaths.profileDirectory(gameName: newName)
+                guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
+                    isNameDuplicate = true
+                    nameEditorError = "game.form.name.duplicate".localized()
+                    isSavingGameName = false
+                    return
+                }
+
                 if FileManager.default.fileExists(atPath: oldDirectory.path) {
                     try FileManager.default.moveItem(at: oldDirectory, to: newDirectory)
                 }
-            }
+                updatedGame.gameName = newName
 
-            updatedGame.gameName = newName
-            Task { @MainActor in
                 do {
                     try await gameRepository.updateGame(updatedGame)
-                    container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
-                    performRefresh()
                 } catch {
                     if FileManager.default.fileExists(atPath: newDirectory.path),
                        !FileManager.default.fileExists(atPath: oldDirectory.path) {
                         try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
                     }
-                    container.core.errorHandler.handle(GlobalError.from(error))
+                    throw error
                 }
+
+                showGameNamePopover = false
+                isSavingGameName = false
+                container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
+                performRefresh()
+            } catch {
+                isSavingGameName = false
+                container.core.errorHandler.handle(GlobalError.from(error))
             }
-        } catch {
-            if FileManager.default.fileExists(atPath: newDirectory.path),
-               !FileManager.default.fileExists(atPath: oldDirectory.path) {
-                try? FileManager.default.moveItem(at: newDirectory, to: oldDirectory)
-            }
-            container.core.errorHandler.handle(GlobalError.from(error))
         }
     }
 

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -10,6 +10,14 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct GameInfoDetailView: View {
+    private enum NameValidationState: Equatable {
+        case idle
+        case checking
+        case valid
+        case duplicate
+        case failed(String)
+    }
+
     @Environment(DIContainer.self)
     private var container
     let game: GameVersionInfo
@@ -33,14 +41,13 @@ struct GameInfoDetailView: View {
     @State private var ioViewModel = GameInfoDetailIOViewModel()
 
     @State private var scannedResources: Set<String> = []
-    @State private var header: AnyView?
     @State private var showIconFilePicker = false
     @State private var showGameNamePopover = false
     @State private var editedGameName = ""
-    @State private var nameEditorError: String?
-    @State private var isNameDuplicate = false
-    @State private var isCheckingName = false
+    @State private var nameValidationState: NameValidationState = .idle
+    @State private var nameValidationRequestID = UUID()
     @State private var isSavingGameName = false
+    @State private var isGameRunningForNameEdit = false
 
     init(
         game: GameVersionInfo,
@@ -110,12 +117,6 @@ struct GameInfoDetailView: View {
         .onChange(of: game.gameName) { _, _ in
             performRefresh()
         }
-        .onChange(of: game.modLoader) { _, _ in
-            updateHeaders()
-        }
-        .onChange(of: game.modVersion) { _, _ in
-            updateHeaders()
-        }
         .onChange(of: gameType) { _, _ in
             performRefresh()
         }
@@ -140,11 +141,7 @@ struct GameInfoDetailView: View {
             }
         }
         .onAppear {
-            updateHeaders()
             container.core.cacheInfoManager.calculateGameCacheInfo(game.gameName)
-        }
-        .onChange(of: container.core.cacheInfoManager.cacheInfo) { _, _ in
-            updateHeaders()
         }
         .onDisappear {
             clearAllData()
@@ -159,7 +156,6 @@ struct GameInfoDetailView: View {
     }
 
     private func performRefresh() {
-        updateHeaders()
         container.core.cacheInfoManager.calculateGameCacheInfo(game.gameName)
         if !gameType {
             triggerLocalRefresh()
@@ -173,123 +169,127 @@ struct GameInfoDetailView: View {
         localRefreshToken = UUID()
     }
 
-    private func updateHeaders() {
+    private var header: AnyView {
         let currentGame = gameRepository.games.first { $0.id == game.id } ?? game
 
-        let headerView = GameHeaderListRow(
-            game: currentGame,
-            cacheInfo: container.core.cacheInfoManager.cacheInfo,
-            query: query,
-        ) {
-            showIconFilePicker = true
-        } onNameTap: {
-            beginGameNameEditing()
-        }
-        .popover(isPresented: $showGameNamePopover, arrowEdge: .bottom) {
-            gameNameEditorPopover
-        }
-        header = AnyView(headerView)
+        return AnyView(
+            GameHeaderListRow(
+                game: currentGame,
+                cacheInfo: container.core.cacheInfoManager.cacheInfo,
+                query: query,
+            ) {
+                showIconFilePicker = true
+            } onNameTap: {
+                beginGameNameEditing()
+            }
+            .popover(isPresented: $showGameNamePopover, arrowEdge: .bottom) {
+                gameNameEditorPopover
+            },
+        )
     }
 
     private var gameNameEditorPopover: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("game.form.name".localized())
-                .font(.headline)
+        HStack(spacing: 12) {
             TextField("game.form.name.placeholder".localized(), text: $editedGameName)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit(saveGameName)
-            if isNameDuplicate {
-                Text("game.form.name.duplicate".localized())
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            } else if let nameEditorError {
-                Text(nameEditorError)
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            }
-            HStack {
-                Spacer()
-                Button("common.confirm".localized(), action: saveGameName)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(
-                        isSavingGameName
-                            || isCurrentGameRunning
-                            || isCheckingName
-                            || isNameDuplicate
-                            || editedGameName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            || editedGameName == game.gameName,
-                    )
-            }
+                .frame(width: 340)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(nameValidationMessage == nil ? Color.clear : Color.red, lineWidth: 1)
+                }
+                .help(nameValidationMessage ?? "")
+                .onSubmit {
+                    guard canConfirmGameName else { return }
+                    saveGameName()
+                }
+            Button("common.confirm".localized(), action: saveGameName)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canConfirmGameName)
         }
         .padding()
-        .frame(width: 300)
-        .task(id: editedGameName) {
-            await validateEditedGameName()
+        .onChange(of: editedGameName) { _, newValue in
+            validateEditedGameName(newValue)
+        }
+    }
+
+    private var nameValidationMessage: String? {
+        switch nameValidationState {
+        case .duplicate:
+            "game.form.name.duplicate".localized()
+        case let .failed(message):
+            message
+        case .idle, .checking, .valid:
+            nil
         }
     }
 
     private func beginGameNameEditing() {
-        editedGameName = game.gameName
-        nameEditorError = nil
-        isNameDuplicate = false
+        editedGameName = currentGameName
+        nameValidationState = .idle
+        nameValidationRequestID = UUID()
+        isGameRunningForNameEdit = isCurrentGameRunning
         showGameNamePopover = true
+    }
+
+    private var currentGameName: String {
+        gameRepository.getGame(by: game.id)?.gameName ?? game.gameName
     }
 
     private var isCurrentGameRunning: Bool {
         container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
     }
 
-    private func validateEditedGameName() async {
-        let newName = editedGameName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !newName.isEmpty, newName != game.gameName else {
-            isNameDuplicate = false
-            isCheckingName = false
+    private var canConfirmGameName: Bool {
+        nameValidationState == .valid
+            && !isSavingGameName
+            && !isGameRunningForNameEdit
+    }
+
+    private func validateEditedGameName(_ value: String) {
+        let newName = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestID = UUID()
+        nameValidationRequestID = requestID
+
+        guard !newName.isEmpty, newName != currentGameName else {
+            nameValidationState = .idle
             return
         }
 
-        isCheckingName = true
-        defer { isCheckingName = false }
-        do {
-            let exists = try await gameRepository.gameNameExists(newName, excludingID: game.id)
-            guard !Task.isCancelled else { return }
-            isNameDuplicate = exists
-        } catch {
-            guard !Task.isCancelled else { return }
-            isNameDuplicate = true
-            nameEditorError = GlobalError.from(error).localizedDescription
+        nameValidationState = .checking
+        Task { @MainActor in
+            do {
+                let exists = try await gameRepository.gameNameExists(newName, excludingID: game.id)
+                guard requestID == nameValidationRequestID else { return }
+                nameValidationState = exists ? .duplicate : .valid
+            } catch {
+                guard requestID == nameValidationRequestID else { return }
+                nameValidationState = .failed(GlobalError.from(error).localizedDescription)
+            }
         }
     }
 
     private func saveGameName() {
-        guard !isSavingGameName else { return }
+        guard canConfirmGameName else { return }
         let newName = editedGameName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !newName.isEmpty, newName != game.gameName else { return }
 
         isSavingGameName = true
-        nameEditorError = nil
         Task { @MainActor in
+            defer { isSavingGameName = false }
             do {
                 guard !isCurrentGameRunning else {
-                    isSavingGameName = false
+                    isGameRunningForNameEdit = true
                     return
                 }
-                guard var updatedGame = gameRepository.getGame(by: game.id) else {
-                    isSavingGameName = false
-                    return
-                }
+                guard var updatedGame = gameRepository.getGame(by: game.id) else { return }
                 guard try await !gameRepository.gameNameExists(newName, excludingID: game.id) else {
-                    isNameDuplicate = true
-                    nameEditorError = "game.form.name.duplicate".localized()
-                    isSavingGameName = false
+                    nameValidationState = .duplicate
                     return
                 }
 
                 let oldDirectory = AppPaths.profileDirectory(gameName: updatedGame.gameName)
                 let newDirectory = AppPaths.profileDirectory(gameName: newName)
                 guard !FileManager.default.fileExists(atPath: newDirectory.path) else {
-                    isNameDuplicate = true
-                    nameEditorError = "game.form.name.duplicate".localized()
-                    isSavingGameName = false
+                    nameValidationState = .duplicate
                     return
                 }
 
@@ -309,11 +309,9 @@ struct GameInfoDetailView: View {
                 }
 
                 showGameNamePopover = false
-                isSavingGameName = false
                 container.ui.iconRefreshNotifier.notifyRefresh(for: nil)
                 performRefresh()
             } catch {
-                isSavingGameName = false
                 container.core.errorHandler.handle(GlobalError.from(error))
             }
         }
@@ -355,7 +353,6 @@ struct GameInfoDetailView: View {
                     }
                 }
                 container.ui.iconRefreshNotifier.notifyRefresh(for: gameName)
-                updateHeaders()
             }
         }
     }

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -26,8 +26,6 @@ struct GameInfoDetailView: View {
     @Binding var gameType: Bool
     @Environment(GameRepository.self)
     private var gameRepository
-    @Environment(PlayerListViewModel.self)
-    private var playerListViewModel
     @Binding var selectedItem: SidebarItem
     @Binding var searchText: String
     @Binding var localResourceFilter: LocalResourceFilter
@@ -216,7 +214,6 @@ struct GameInfoDetailView: View {
                     .disabled(
                         isSavingGameName
                             || isCurrentGameRunning
-                            || isCurrentGameLaunching
                             || isCheckingName
                             || isNameDuplicate
                             || editedGameName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -238,16 +235,8 @@ struct GameInfoDetailView: View {
         showGameNamePopover = true
     }
 
-    private var currentUserID: String {
-        playerListViewModel.currentPlayer?.id ?? ""
-    }
-
     private var isCurrentGameRunning: Bool {
         container.core.gameProcessManager.isGameRunningForAnyUser(gameId: game.id)
-    }
-
-    private var isCurrentGameLaunching: Bool {
-        container.core.gameStatusManager.isGameLaunching(gameId: game.id, userId: currentUserID)
     }
 
     private func validateEditedGameName() async {
@@ -280,7 +269,7 @@ struct GameInfoDetailView: View {
         nameEditorError = nil
         Task { @MainActor in
             do {
-                guard !isCurrentGameRunning, !isCurrentGameLaunching else {
+                guard !isCurrentGameRunning else {
                     isSavingGameName = false
                     return
                 }

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameInfoDetailView.swift
@@ -259,6 +259,7 @@ struct GameInfoDetailView: View {
         }
 
         isCheckingName = true
+        defer { isCheckingName = false }
         do {
             let exists = try await gameRepository.gameNameExists(newName, excludingID: game.id)
             guard !Task.isCancelled else { return }
@@ -268,7 +269,6 @@ struct GameInfoDetailView: View {
             isNameDuplicate = true
             nameEditorError = GlobalError.from(error).localizedDescription
         }
-        isCheckingName = false
     }
 
     private func saveGameName() {

--- a/SwiftCraftLauncher/MainFeature/Views/Toolbar/GameActionButtons.swift
+++ b/SwiftCraftLauncher/MainFeature/Views/Toolbar/GameActionButtons.swift
@@ -94,7 +94,7 @@ struct GameActionButtons: View {
 
             if detailState.gameType == false,
                detailState.gameResourcesType == ResourceType.minecraftJavaServer.rawValue
-                   || game.modLoader != GameLoader.vanilla.displayName {
+               || game.modLoader != GameLoader.vanilla.displayName {
                 ResourceImportButton(
                     game: game,
                     gameResourcesType: detailState.gameResourcesType,

--- a/SwiftCraftLauncherTests/GameFeature/GameHeaderViewModelTests.swift
+++ b/SwiftCraftLauncherTests/GameFeature/GameHeaderViewModelTests.swift
@@ -1,0 +1,26 @@
+//
+//  GameHeaderViewModelTests.swift
+//  SwiftCraftLauncherTests
+//
+//  © 2025-2026 Swift Craft Launcher Team. All rights reserved.
+//
+
+@testable import SwiftCraftLauncher
+import XCTest
+
+@MainActor
+final class GameHeaderViewModelTests: XCTestCase {
+    func testNameValidationRejectsEmptyAndUnchangedNames() {
+        let viewModel = GameHeaderViewModel()
+
+        XCTAssertFalse(viewModel.isNameValid(newName: "  ", currentName: "Current"))
+        XCTAssertFalse(viewModel.isNameValid(newName: " Current ", currentName: "Current"))
+    }
+
+    func testNameValidationAcceptsUnusedName() {
+        let viewModel = GameHeaderViewModel()
+        let uniqueName = "scl-rename-test-\(UUID().uuidString)"
+
+        XCTAssertTrue(viewModel.isNameValid(newName: uniqueName, currentName: "Current"))
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Enable direct game renaming from the game detail view while preserving profile data and validating name conflicts.

New Features:
- Allow users to rename games directly from the game detail header.

Enhancements:
- Keep game profile directories synchronized with renamed game records and restore the directory if persistence fails.

Tests:
- Add coverage for game name validation, including empty, unchanged, and unused names.