### PR TITLE
fix(log):将日志的隐私策略更改为 .public 使日志参数可视

### DIFF
--- a/SwiftCraftLauncher/CommonFeature/Utilities/Logger.swift
+++ b/SwiftCraftLauncher/CommonFeature/Utilities/Logger.swift
@@ -8,23 +8,48 @@
 import Foundation
 import os.log
 
+/// Writes already-reviewed application log messages with visible interpolation values.
+struct VisibleLogger: Sendable {
+    private let logger: Logger
+
+    init(subsystem: String, category: String) {
+        logger = Logger(subsystem: subsystem, category: category)
+    }
+
+    func debug(_ message: String) {
+        logger.debug("\(message, privacy: .public)")
+    }
+
+    func info(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
+    func warning(_ message: String) {
+        logger.warning("\(message, privacy: .public)")
+    }
+
+    func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+    }
+}
+
 /// Centralized module loggers for the application.
 enum AppLog {
     /// Common infrastructure, networking, authentication, and shared utilities.
-    static let common = os.Logger(subsystem: Bundle.main.identifier, category: "common")
+    static let common = VisibleLogger(subsystem: Bundle.main.identifier, category: "common")
 
     /// Game lifecycle: launch, Java management, mod scanning, version setup.
-    static let game = os.Logger(subsystem: Bundle.main.identifier, category: "game")
+    static let game = VisibleLogger(subsystem: Bundle.main.identifier, category: "game")
 
     /// Player profiles, skins, and authentication accounts.
-    static let player = os.Logger(subsystem: Bundle.main.identifier, category: "player")
+    static let player = VisibleLogger(subsystem: Bundle.main.identifier, category: "player")
 
     /// Remote resource browsing (Modrinth / CurseForge) and dependency resolution.
-    static let resource = os.Logger(subsystem: Bundle.main.identifier, category: "resource")
+    static let resource = VisibleLogger(subsystem: Bundle.main.identifier, category: "resource")
 
     /// Mod-pack import, export, and installation workflows.
-    static let modPack = os.Logger(subsystem: Bundle.main.identifier, category: "modpack")
+    static let modPack = VisibleLogger(subsystem: Bundle.main.identifier, category: "modpack")
 
     /// Main window, menus, and top-level UI coordination.
-    static let main = os.Logger(subsystem: Bundle.main.identifier, category: "main")
+    static let main = VisibleLogger(subsystem: Bundle.main.identifier, category: "main")
 }

--- a/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
+++ b/SwiftCraftLauncher/GameFeature/ViewModels/GameDetail/GameHeaderViewModel.swift
@@ -18,13 +18,15 @@ final class GameHeaderViewModel {
     func isNameValid(newName: String, currentName: String, gameId: String) -> Bool {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed != currentName else { return false }
-        if DIContainer.shared.core.gameProcessManager.isGameRunningForAnyUser(gameId: gameId) { return false }
+        if DIContainer.shared.core.gameProcessManager.isGameRunningForAnyUser(gameId: gameId) {
+            return false
+        }
         return !FileManager.default.fileExists(
-            atPath: AppPaths.profileDirectory(gameName: trimmed).path
+            atPath: AppPaths.profileDirectory(gameName: trimmed).path,
         )
     }
 
-    func performRename(gameId: String, currentName: String, gameRepository: GameRepository) async {
+    func performRename(gameId: String, currentName _: String, gameRepository: GameRepository) async {
         do {
             try await gameRepository.renameGame(id: gameId, to: newName.trimmingCharacters(in: .whitespacesAndNewlines))
         } catch {

--- a/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
+++ b/SwiftCraftLauncher/GameFeature/Views/GameDetail/GameHeaderListRow.swift
@@ -8,7 +8,7 @@
 import Combine
 import SwiftUI
 
-// A list row displaying the game icon, name, version info, and cache size.
+/// A list row displaying the game icon, name, version info, and cache size.
 struct GameHeaderListRow: View {
     @Environment(DIContainer.self)
     private var container


### PR DESCRIPTION
logger.swift 前面加了
```Swift
struct VisibleLogger: Sendable {
    private let logger: Logger

    init(subsystem: String, category: String) {
        logger = Logger(subsystem: subsystem, category: category)
    }

    func debug(_ message: String) {
        logger.debug("\(message, privacy: .public)")
    }

    func info(_ message: String) {
        logger.info("\(message, privacy: .public)")
    }

    func warning(_ message: String) {
        logger.warning("\(message, privacy: .public)")
    }

    func error(_ message: String) {
        logger.error("\(message, privacy: .public)")
    }
}
```

则使用 `VisibleLogger` 输出的日志的隐私策略为 `.public`，并将后面的 `os.logger` 改为 `VisibleLogger`

## Summary by Sourcery

Expose reviewed application log parameters while retaining centralized logging across the app.

Bug Fixes:
- Make application log message parameters visible by default when using the centralized loggers.

Enhancements:
- Standardize application logging through a sendable wrapper that preserves the existing module-specific logger categories.

Chores:
- Apply minor Swift style and cleanup updates in the game header view model and row.