### PR TITLE
feat: 调整三方登录设置的显示逻辑

### DIFF
--- a/SwiftCraftLauncher/PlayerFeature/Managers/PremiumAccountFlagManager.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Managers/PremiumAccountFlagManager.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import Observation
 
 /// Tracks whether a premium (Mojang/Microsoft) account has ever been added.
 ///
 /// This flag determines whether offline account creation is permitted.
+@Observable
 class PremiumAccountFlagManager {
     init() { }
 
@@ -22,5 +24,15 @@ class PremiumAccountFlagManager {
     func setPremiumAccountAdded() {
         Defaults.save(true, forKey: AppConstants.UserDefaultsKeys.hasAddedPremiumAccount)
         AppLog.player.debug("Premium account added flag set")
+    }
+
+    /// Whether offline account creation is permitted.
+    /// Returns `true` if a premium account has been added or the user is not on a foreign IP.
+    func canAddOfflineAccount(ipLocationService: IPLocationService) async -> Bool {
+        if hasAddedPremiumAccount() {
+            return true
+        }
+        let foreign = (try? await ipLocationService.isForeignIPThrowing()) ?? true
+        return !foreign
     }
 }

--- a/SwiftCraftLauncher/PlayerFeature/ViewModels/AddPlayer/AddPlayerSheetViewModel.swift
+++ b/SwiftCraftLauncher/PlayerFeature/ViewModels/AddPlayer/AddPlayerSheetViewModel.swift
@@ -40,13 +40,11 @@ final class AddPlayerSheetViewModel {
 
     /// Checks whether a premium account flag exists and detects foreign IP if not.
     func checkPremiumAccountFlag() async {
-        let hasFlag = DIContainer.shared.system.premiumAccountFlagManager.hasAddedPremiumAccount()
-
-        if !hasFlag {
-            // If IP detection fails, assume foreign as a conservative default.
-            let foreign = (try? await DIContainer.shared.system.ipLocationService.isForeignIPThrowing()) ?? true
-            isForeignIP = foreign
-        }
+        let container = DIContainer.shared.system
+        let canAdd = await container.premiumAccountFlagManager.canAddOfflineAccount(
+            ipLocationService: container.ipLocationService,
+        )
+        isForeignIP = !canAdd
 
         isCheckingFlag = false
 

--- a/SwiftCraftLauncher/PlayerFeature/Views/Settings/PlayerSettingsView.swift
+++ b/SwiftCraftLauncher/PlayerFeature/Views/Settings/PlayerSettingsView.swift
@@ -17,6 +17,7 @@ public struct PlayerSettingsView: View {
     @State private var viewModel = PlayerSettingsViewModel()
     @Environment(PlayerListViewModel.self)
     private var playerListViewModel
+    @State private var canAddOffline: Bool = false
 
     private var currentPlayer: Player? {
         playerListViewModel.currentPlayer
@@ -30,7 +31,9 @@ public struct PlayerSettingsView: View {
     public var body: some View {
         Form {
             PlayerSettingsEphemeralLoginRow()
-            PlayerSettingsOfflineLoginRow()
+            if canAddOffline {
+                PlayerSettingsOfflineLoginRow()
+            }
             PlayerSettingsDefaultSkinServerRow()
             spacerView()
             if isMinecraftAccount {
@@ -44,6 +47,10 @@ public struct PlayerSettingsView: View {
         .environment(playerSettingsManager)
         .task(id: currentPlayer?.id) {
             viewModel.refreshAuthlibInjectorExists()
+            let container = DIContainer.shared.system
+            canAddOffline = await container.premiumAccountFlagManager.canAddOfflineAccount(
+                ipLocationService: container.ipLocationService,
+            )
             guard let p = currentPlayer, p.isOnlineAccount else {
                 viewModel.clearMinecraftFriendAccountPreferences()
                 return


### PR DESCRIPTION
feat: 调整三方登录设置的显示逻辑

## Summary by Sourcery

Restrict the display of offline login settings to users who are permitted to create offline accounts.

Enhancements:
- Centralize offline-account availability checks and make them observable for UI consumers.
- Show the offline login option in player settings only when the account or network location permits offline account creation.